### PR TITLE
Pin Scala 3.3 LTS in scala steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -4,6 +4,8 @@ updates.pin = [
   # To be updated in tandem with upstream Pekko
   {groupId = "com.fasterxml.jackson.core", version = "2.11."}
   {groupId = "org.scalatest", artifactId = "scalatest", version = "3.1."}
+  # Scala 3.3 is a LTS
+  { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
 ]
 
 updates.ignore = [


### PR DESCRIPTION
I noticed in Scala OS projects that Scala Steward has been bumping 3.3.x to 3.4.x