### PR TITLE
Pin wiremock to 2.x

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -5,7 +5,9 @@ updates.pin = [
   # Scala 3.3 is a LTS
   { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
   # Pin logback to v1.3.x because v1.4.x needs JDK11
-  { groupId = "ch.qos.logback", version="1.3." }
+  { groupId = "ch.qos.logback", version = "1.3." }
+  # Pin wiremock to v2.x because v3.x needs JDK11
+  { groupId = "com.github.tomakehurst", artifactId = "2.", version="1.3." }
 ]
 
 updates.ignore = [


### PR DESCRIPTION
replaces #183 until we drop support for Java 8