### PR TITLE
Add pekko-lease-kubernetes to same version check

### DIFF
--- a/management/src/main/scala/org/apache/pekko/management/scaladsl/PekkoManagement.scala
+++ b/management/src/main/scala/org/apache/pekko/management/scaladsl/PekkoManagement.scala
@@ -65,6 +65,7 @@ final class PekkoManagement(implicit private[pekko] val system: ExtendedActorSys
       "pekko-discovery-marathon-api",
       "pekko-discovery-aws-api-async",
       "pekko-discovery-kubernetes-api",
+      "pekko-lease-kubernetes",
       "pekko-management",
       "pekko-management-cluster-bootstrap",
       "pekko-management-cluster-http"),


### PR DESCRIPTION
Applying this PR will add pekko-lease-kubernetes to the list of dependencies that are checked to have the same version. I think this was missed when the module was introduced.