### PR TITLE
Fix version numbers

### DIFF
--- a/integration-test/dns-api-mesos/build.sbt
+++ b/integration-test/dns-api-mesos/build.sbt
@@ -20,4 +20,4 @@ libraryDependencies += "org.apache.pekko" %% "pekko-management-cluster-bootstrap
 libraryDependencies += "org.apache.pekko" %% "pekko-management-cluster-http" % pekkoManagementVersion(
   version.value)
 
-libraryDependencies += "org.apache.pekko" %% "pekko-discovery" % "2.5.20"
+libraryDependencies += "org.apache.pekko" %% "pekko-discovery" % "1.0.2"

--- a/integration-test/marathon-api/build.sbt
+++ b/integration-test/marathon-api/build.sbt
@@ -15,7 +15,7 @@ version := "1.1.4"
 
 scalaVersion := "2.13.11"
 
-val pekkoManagementVersion = "1.10.0"
+val pekkoManagementVersion = "1.0.0"
 
 libraryDependencies ++= Vector(
   "org.apache.pekko" %% "pekko-management-cluster-bootstrap" % pekkoManagementVersion,


### PR DESCRIPTION
The version numbers refer to akka, not pekko versions, making the examples not compile.