### PR TITLE
upgrade to manusa/actions-setup-minikube@v2.11.0

### DIFF
--- a/.github/workflows/integration-tests-kube-api.yml
+++ b/.github/workflows/integration-tests-kube-api.yml
@@ -39,7 +39,7 @@ jobs:
         uses: coursier/cache-action@v6
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.10.0
+        uses: manusa/actions-setup-minikube@v2.11.0
         with:
           minikube version: 'v1.27.1' # based on k8s v1.25.2
           kubernetes version: 'v1.25.2'

--- a/.github/workflows/integration-tests-kube-dns.yml
+++ b/.github/workflows/integration-tests-kube-dns.yml
@@ -39,7 +39,7 @@ jobs:
         uses: coursier/cache-action@v6
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.10.0
+        uses: manusa/actions-setup-minikube@v2.11.0
         with:
           minikube version: 'v1.27.1' # based on k8s v1.25.2
           kubernetes version: 'v1.25.2'

--- a/.github/workflows/integration-tests-lease.yml
+++ b/.github/workflows/integration-tests-lease.yml
@@ -39,7 +39,7 @@ jobs:
         uses: coursier/cache-action@v6
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.10.0
+        uses: manusa/actions-setup-minikube@v2.11.0
         with:
           minikube version: 'v1.27.1' # based on k8s v1.25.2
           kubernetes version: 'v1.25.2'

--- a/.github/workflows/integration-tests-maven.yml
+++ b/.github/workflows/integration-tests-maven.yml
@@ -38,7 +38,7 @@ jobs:
         uses: coursier/cache-action@v6
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.10.0
+        uses: manusa/actions-setup-minikube@v2.11.0
         with:
           minikube version: 'v1.27.1' # based on k8s v1.25.2
           kubernetes version: 'v1.25.2'


### PR DESCRIPTION
due to node version - GitHub CI is withdrawing support for node16