### PR TITLE
Add native leases support in integration tests

### DIFF
--- a/.github/workflows/integration-tests-lease.yml
+++ b/.github/workflows/integration-tests-lease.yml
@@ -58,7 +58,8 @@ jobs:
           kubectl proxy --port=8080 &
           echo 'Running tests'
           sbt ";lease-kubernetes/it:test"
-          ./lease-kubernetes-int-test/test.sh
+          ./lease-kubernetes-int-test/test.sh job.yml
+          ./lease-kubernetes-int-test/test.sh job-native.yml
 
       - name: Print logs on failure
         if: ${{ failure() }}

--- a/lease-kubernetes-int-test/kubernetes/job-native.yml
+++ b/lease-kubernetes-int-test/kubernetes/job-native.yml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: lease-test
+spec:
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    spec:
+      containers:
+        - name: lease-test
+          imagePullPolicy: Never
+          image: pekko-lease-kubernetes-int-test:latest
+          env:
+            - name: LEASE_CLASS
+              value: "org.apache.pekko.coordination.lease.kubernetes.NativeKubernetesLease"
+      restartPolicy: Never

--- a/lease-kubernetes-int-test/kubernetes/rbac.yml
+++ b/lease-kubernetes-int-test/kubernetes/rbac.yml
@@ -3,7 +3,16 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: lease-access
 rules:
-  - apiGroups: ["akka.io"]
+  - apiGroups: ["pekko.apache.org"]
+    resources: ["leases"]
+    verbs: ["get", "create", "update", "delete", "list"]
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: native-lease-access
+rules:
+  - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "create", "update", "delete", "list"]
 ---
@@ -20,4 +29,16 @@ subjects:
 roleRef:
   kind: Role
   name: lease-access
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: native-lease-access
+subjects:
+  - kind: ServiceAccount
+    name: default
+roleRef:
+  kind: Role
+  name: native-lease-access
   apiGroup: rbac.authorization.k8s.io

--- a/lease-kubernetes-int-test/src/main/resources/application.conf
+++ b/lease-kubernetes-int-test/src/main/resources/application.conf
@@ -14,4 +14,6 @@ pekko {
       }
     }
   }
+  # Possibility to modify lease class via environment, if not set will take default value
+  coordination.lease.kubernetes.lease-class = ${?LEASE_CLASS}
 }

--- a/lease-kubernetes-int-test/src/main/scala/org/apache/pekko/coordination/lease/kubernetes/LeaseTestSuite.scala
+++ b/lease-kubernetes-int-test/src/main/scala/org/apache/pekko/coordination/lease/kubernetes/LeaseTestSuite.scala
@@ -50,9 +50,11 @@ object LeaseTestSuite {
       case Success(_) =>
         log.info("Test failed, see the logs")
         CoordinatedShutdown(as).run(TestFailedReason)
+        System.exit(1)
       case Failure(exception) =>
         log.error(exception, "Test exception")
         CoordinatedShutdown(as).run(TestFailedReason)
+        System.exit(1)
     }
   }
 

--- a/lease-kubernetes-int-test/test.sh
+++ b/lease-kubernetes-int-test/test.sh
@@ -6,12 +6,13 @@ set -exu
 
 JOB_NAME=lease-test
 PROJECT_DIR=lease-kubernetes-int-test
+JOB_YML=$1
 
 eval $(minikube -p minikube docker-env)
 sbt "lease-kubernetes-int-test / docker:publishLocal"
 
-kubectl apply -f $PROJECT_DIR/kubernetes/rbac.yml
-kubectl delete -f $PROJECT_DIR/kubernetes/job.yml || true
+kubectl apply -f "$PROJECT_DIR/kubernetes/rbac.yml"
+kubectl delete -f "$PROJECT_DIR/kubernetes/$JOB_YML" || true
 
 for i in {1..10}
 do
@@ -22,7 +23,7 @@ done
 
 echo "Old jobs cleaned up. Creating new job"
 
-kubectl create -f $PROJECT_DIR/kubernetes/job.yml
+kubectl create -f "$PROJECT_DIR/kubernetes/$JOB_YML"
 
 # Add in a default sleep when we know a min amount of time it'll take
 

--- a/lease-kubernetes/src/it/scala/org/apache/pekko/coordination/lease/kubernetes/AbstractKubernetesApiIntegrationTest.scala
+++ b/lease-kubernetes/src/it/scala/org/apache/pekko/coordination/lease/kubernetes/AbstractKubernetesApiIntegrationTest.scala
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.coordination.lease.kubernetes
+
+import com.typesafe.config.ConfigFactory
+import org.apache.pekko
+import pekko.Done
+import pekko.actor.ActorSystem
+import pekko.coordination.lease.kubernetes.internal.AbstractKubernetesApiImpl
+import pekko.testkit.TestKit
+import org.scalatest.concurrent.{ Eventually, ScalaFutures }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.{ BeforeAndAfterAll, CancelAfterFailure }
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/**
+ * This test requires an API server available on localhost:8080, the lease CRD created and a namespace called lease
+ *
+ * One way of doing this is to have a kubectl proxy open:
+ *
+ * `kubectl proxy --port=8080`
+ */
+abstract class AbstractKubernetesApiIntegrationTest extends TestKit(ActorSystem("KubernetesApiIntegrationSpec",
+      ConfigFactory.parseString(
+        """
+    pekko.loglevel = DEBUG
+    pekko.coordination.lease.kubernetes.lease-operation-timeout = 1.5s
+    """)))
+    with AnyWordSpecLike with Matchers
+    with ScalaFutures with BeforeAndAfterAll with CancelAfterFailure with Eventually {
+
+  val underTest: AbstractKubernetesApiImpl
+
+  implicit val patience: PatienceConfig = PatienceConfig(testKitSettings.DefaultTimeout.duration)
+
+  val settings = new KubernetesSettings(
+    "",
+    "",
+    "localhost",
+    8080,
+    namespace = Some("lease"),
+    "",
+    apiServerRequestTimeout = 1.second,
+    false)
+  val leaseName = "lease-1"
+  val client1 = "client-1"
+  val client2 = "client-2"
+  var currentVersion = ""
+
+  override protected def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  override protected def beforeAll(): Unit = {
+    // do some operation to check the proxy is up
+    eventually {
+      Await.result(underTest.removeLease(leaseName), 2.second) shouldEqual Done
+    }
+  }
+
+  "Kubernetes lease resource" should {
+    "be able to be created" in {
+      val leaseRecord = underTest.readOrCreateLeaseResource(leaseName).futureValue
+      leaseRecord.owner shouldEqual None
+      leaseRecord.version shouldNot equal("")
+      leaseRecord.version shouldNot equal(null)
+      currentVersion = leaseRecord.version
+    }
+
+    "be able to read back with same version" in {
+      val leaseRecord = underTest.readOrCreateLeaseResource(leaseName).futureValue
+      leaseRecord.version shouldEqual currentVersion
+    }
+
+    "be able to take a lease with no owner" in {
+      val leaseRecord = underTest.updateLeaseResource(leaseName, client1, currentVersion).futureValue
+      val success: LeaseResource = leaseRecord match {
+        case Right(lr) => lr
+        case Left(_)   => fail("There shouldn't be anyone else updating the resource.")
+      }
+      success.version shouldNot equal(currentVersion)
+      currentVersion = success.version
+      success.owner shouldEqual Some(client1)
+    }
+
+    "be able to update a lease if resource version is correct" in {
+      val timeUpdate = System.currentTimeMillis()
+      val leaseRecord = underTest.updateLeaseResource(leaseName, client1, currentVersion, time = timeUpdate).futureValue
+      val success: LeaseResource = leaseRecord match {
+        case Right(lr) => lr
+        case Left(_)   => fail("There shouldn't be anyone else updating the resource.")
+      }
+      success.version shouldNot equal(currentVersion)
+      currentVersion = success.version
+      success.owner shouldEqual Some(client1)
+      success.time shouldEqual timeUpdate
+    }
+
+    "not be able to update a lease if resource version is correct" in {
+      val timeUpdate = System.currentTimeMillis()
+      val leaseRecord = underTest.updateLeaseResource(leaseName, client1, "10", time = timeUpdate).futureValue
+      val failure: LeaseResource = leaseRecord match {
+        case Right(_) => fail("Expected update failure (we've used an invalid version!).")
+        case Left(lr) => lr
+      }
+      failure.version shouldEqual currentVersion
+      currentVersion = failure.version
+      failure.owner shouldEqual Some(client1)
+      failure.time shouldNot equal(timeUpdate)
+    }
+
+    "be able to remove ownership" in {
+      val leaseRecord = underTest.updateLeaseResource(leaseName, "", currentVersion).futureValue
+      val success: LeaseResource = leaseRecord match {
+        case Right(lr) => lr
+        case Left(_)   => fail("There shouldn't be anyone else updating the resource.")
+      }
+      success.version shouldNot equal(currentVersion)
+      currentVersion = success.version
+      success.owner shouldEqual None
+    }
+
+    "be able to get lease once other client has removed" in {
+      val leaseRecord = underTest.updateLeaseResource(leaseName, client2, currentVersion).futureValue
+      val success: LeaseResource = leaseRecord match {
+        case Right(lr) => lr
+        case Left(_)   => fail("There shouldn't be anyone else updating the resource.")
+      }
+      success.version shouldNot equal(currentVersion)
+      currentVersion = success.version
+      success.owner shouldEqual Some(client2)
+    }
+  }
+
+}

--- a/lease-kubernetes/src/it/scala/org/apache/pekko/coordination/lease/kubernetes/KubernetesApiIntegrationTest.scala
+++ b/lease-kubernetes/src/it/scala/org/apache/pekko/coordination/lease/kubernetes/KubernetesApiIntegrationTest.scala
@@ -10,18 +10,7 @@
 package org.apache.pekko.coordination.lease.kubernetes
 
 import org.apache.pekko
-import pekko.Done
-import pekko.actor.ActorSystem
 import pekko.coordination.lease.kubernetes.internal.KubernetesApiImpl
-import pekko.testkit.TestKit
-import com.typesafe.config.ConfigFactory
-import org.scalatest.{ BeforeAndAfterAll, CancelAfterFailure }
-import org.scalatest.concurrent.{ Eventually, ScalaFutures }
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpecLike
-
-import scala.concurrent.Await
-import scala.concurrent.duration._
 
 /**
  * This test requires an API server available on localhost:8080, the lease CRD created and a namespace called lease
@@ -30,116 +19,7 @@ import scala.concurrent.duration._
  *
  * `kubectl proxy --port=8080`
  */
-class KubernetesApiIntegrationTest extends TestKit(ActorSystem("KubernetesApiIntegrationSpec",
-      ConfigFactory.parseString(
-        """
-    pekko.loglevel = DEBUG
-    pekko.coordination.lease.kubernetes.lease-operation-timeout = 1.5s
-    """)))
-    with AnyWordSpecLike with Matchers
-    with ScalaFutures with BeforeAndAfterAll with CancelAfterFailure with Eventually {
-
-  implicit val patience: PatienceConfig = PatienceConfig(testKitSettings.DefaultTimeout.duration)
-
-  val settings = new KubernetesSettings(
-    "",
-    "",
-    "localhost",
-    8080,
-    namespace = Some("lease"),
-    "",
-    apiServerRequestTimeout = 1.second,
-    false)
+class KubernetesApiIntegrationTest extends AbstractKubernetesApiIntegrationTest {
 
   val underTest = new KubernetesApiImpl(system, settings)
-  val leaseName = "lease-1"
-  val client1 = "client-1"
-  val client2 = "client-2"
-  var currentVersion = ""
-
-  override protected def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(system)
-  }
-
-  override protected def beforeAll(): Unit = {
-    // do some operation to check the proxy is up
-    eventually {
-      Await.result(underTest.removeLease(leaseName), 2.second) shouldEqual Done
-    }
-  }
-
-  "Kubernetes lease resource" should {
-    "be able to be created" in {
-      val leaseRecord = underTest.readOrCreateLeaseResource(leaseName).futureValue
-      leaseRecord.owner shouldEqual None
-      leaseRecord.version shouldNot equal("")
-      leaseRecord.version shouldNot equal(null)
-      currentVersion = leaseRecord.version
-    }
-
-    "be able to read back with same version" in {
-      val leaseRecord = underTest.readOrCreateLeaseResource(leaseName).futureValue
-      leaseRecord.version shouldEqual currentVersion
-    }
-
-    "be able to take a lease with no owner" in {
-      val leaseRecord = underTest.updateLeaseResource(leaseName, client1, currentVersion).futureValue
-      val success: LeaseResource = leaseRecord match {
-        case Right(lr) => lr
-        case Left(_)   => fail("There shouldn't be anyone else updating the resource.")
-      }
-      success.version shouldNot equal(currentVersion)
-      currentVersion = success.version
-      success.owner shouldEqual Some(client1)
-    }
-
-    "be able to update a lease if resource version is correct" in {
-      val timeUpdate = System.currentTimeMillis()
-      val leaseRecord = underTest.updateLeaseResource(leaseName, client1, currentVersion, time = timeUpdate).futureValue
-      val success: LeaseResource = leaseRecord match {
-        case Right(lr) => lr
-        case Left(_)   => fail("There shouldn't be anyone else updating the resource.")
-      }
-      success.version shouldNot equal(currentVersion)
-      currentVersion = success.version
-      success.owner shouldEqual Some(client1)
-      success.time shouldEqual timeUpdate
-    }
-
-    "not be able to update a lease if resource version is correct" in {
-      val timeUpdate = System.currentTimeMillis()
-      val leaseRecord = underTest.updateLeaseResource(leaseName, client1, "10", time = timeUpdate).futureValue
-      val failure: LeaseResource = leaseRecord match {
-        case Right(_) => fail("Expected update failure (we've used an invalid version!).")
-        case Left(lr) => lr
-      }
-      failure.version shouldEqual currentVersion
-      currentVersion = failure.version
-      failure.owner shouldEqual Some(client1)
-      failure.time shouldNot equal(timeUpdate)
-    }
-
-    "be able to remove ownership" in {
-      val leaseRecord = underTest.updateLeaseResource(leaseName, "", currentVersion).futureValue
-      val success: LeaseResource = leaseRecord match {
-        case Right(lr) => lr
-        case Left(_)   => fail("There shouldn't be anyone else updating the resource.")
-      }
-      success.version shouldNot equal(currentVersion)
-      currentVersion = success.version
-      success.owner shouldEqual None
-    }
-
-    "be able to get lease once other client has removed" in {
-      val leaseRecord = underTest.updateLeaseResource(leaseName, client2, currentVersion).futureValue
-      val success: LeaseResource = leaseRecord match {
-        case Right(lr) => lr
-        case Left(_)   => fail("There shouldn't be anyone else updating the resource.")
-      }
-      success.version shouldNot equal(currentVersion)
-      currentVersion = success.version
-      success.owner shouldEqual Some(client2)
-    }
-  }
-
 }

--- a/lease-kubernetes/src/it/scala/org/apache/pekko/coordination/lease/kubernetes/NativeKubernetesApiIntegrationTest.scala
+++ b/lease-kubernetes/src/it/scala/org/apache/pekko/coordination/lease/kubernetes/NativeKubernetesApiIntegrationTest.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.coordination.lease.kubernetes
+
+import org.apache.pekko
+import pekko.coordination.lease.kubernetes.internal.NativeKubernetesApiImpl
+
+/**
+ * This test requires an API server available on localhost:8080, the lease CRD created and a namespace called lease
+ *
+ * One way of doing this is to have a kubectl proxy open:
+ *
+ * `kubectl proxy --port=8080`
+ */
+class NativeKubernetesApiIntegrationTest extends AbstractKubernetesApiIntegrationTest {
+
+  val underTest = new NativeKubernetesApiImpl(system, settings)
+}


### PR DESCRIPTION
Following #218 , I added integration tests for the native lease.
This has minimal modification on existing tests and includes both a sbt integration test and a .sh modification to run the kubernetes job with the new implementation.

During my testing, it occured to me that the .sh job often fails, but the job is not marked as failed when it does. Is this intended ? For example, after realizing that, when looking at the action results from #217, we can see that the [kubernetes-lease test job](https://github.com/apache/pekko-management/actions/runs/9077822237/job/24943523403) is marked as successful even though it is completely failing from unrenamed rbac (fixed in this PR).