### PR TITLE
ignore broken link in license report

### DIFF
--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -42,6 +42,7 @@ site-link-validator {
     "http://groovy.codehaus.org/"
     "http://www.mockito.org"
     "https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html"
+    "http://servlet-spec.java.net"
     # Occasionally returns a 500 Internal Server Error
     "http://code.google.com/"
   ]


### PR DESCRIPTION
we've got no control over what ends up in the license report and this broken link is failing all the link validator builds