### PR TITLE
Add startup checks

### DIFF
--- a/docs/src/main/paradox/healthchecks.md
+++ b/docs/src/main/paradox/healthchecks.md
@@ -58,14 +58,14 @@ Application specific health checks can be added a `name = <fully qualified class
 Health checks can be hosted via the Pekko management HTTP server. The `pekko.management.HealthCheckRoutes` is enabled
 by default as a Pekko management route provider.
 
-By default all readiness checks are hosted on `/ready` and liveness checks are hosted on `/alive`. If all of the checks
+By default all startup checks are hosted on `/startup`, readiness checks are hosted on `/ready` and liveness checks are hosted on `/alive`. If all of the checks
 for an endpoint succeed a `200` is returned, if any fail or return `false` a `500` is returned. The paths are
-configurable via `pekko.management.health-checks.readiness-path` and `pekko.management.health-checks.liveness-path` e.g.
+configurable via `pekko.management.health-checks.startup-path`, `pekko.management.health-checks.readiness-path` and `pekko.management.health-checks.liveness-path` e.g.
 
 @@snip [application.conf](/integration-test/local/src/main/resources/application.conf)  { #health }
 
 The `org.apache.pekko.management.HealthCheckRoutes` can be disabled with the following configuration but that also
-means that the configured `readiness-checks` and `liveness-checks` will not be used.
+means that the configured `startup-checks`, `readiness-checks` and `liveness-checks` will not be used.
 
 ```
 pekko.management.http.routes {

--- a/integration-test/local/src/main/resources/application.conf
+++ b/integration-test/local/src/main/resources/application.conf
@@ -48,6 +48,7 @@ pekko.discovery {
 
 #health
 pekko.management.health-checks {
+  startup-path = "health/startup"
   readiness-path = "health/ready"
   liveness-path = "health/alive"
 }

--- a/integration-test/local/src/test/scala/org/apache/pekko/management/LocalBootstrapTest.scala
+++ b/integration-test/local/src/test/scala/org/apache/pekko/management/LocalBootstrapTest.scala
@@ -95,6 +95,8 @@ class LocalBootstrapTest extends AnyWordSpec with ScalaFutures with Matchers wit
     super.afterAll()
   }
 
+  def startupStatusCode(port: Int)(implicit system: ActorSystem): StatusCode =
+    healthCheckStatus(port, "health/startup")
   def readyStatusCode(port: Int)(implicit system: ActorSystem): StatusCode =
     healthCheckStatus(port, "health/ready")
   def aliveStatusCode(port: Int)(implicit system: ActorSystem): StatusCode =
@@ -111,6 +113,14 @@ class LocalBootstrapTest extends AnyWordSpec with ScalaFutures with Matchers wit
     systems.foreach(PekkoManagement(_).start())
     // for http client
     implicit val system: ActorSystem = systems(0)
+
+    "not started up initially" in {
+      eventually {
+        managementPorts.foreach { port =>
+          startupStatusCode(port) shouldEqual StatusCodes.InternalServerError
+        }
+      }
+    }
 
     "not be ready initially" in {
       eventually {

--- a/management/src/main/mima-filters/1.1.x.backwards.excludes/startup-checks.backwards.excludes
+++ b/management/src/main/mima-filters/1.1.x.backwards.excludes/startup-checks.backwards.excludes
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Add startup checks
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.management.scaladsl.HealthChecks.startup")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.management.scaladsl.HealthChecks.startupResult")

--- a/management/src/main/resources/reference.conf
+++ b/management/src/main/resources/reference.conf
@@ -55,7 +55,7 @@ pekko.management {
     # The FQCN is the fully qualified class name of the `ManagementRoutesProvider`.
     #
     # By default the `org.apache.pekko.management.HealthCheckRoutes` is enabled, see `health-checks` section of how
-    # configure specific readiness and liveness checks.
+    # configure specific startup, readiness and liveness checks.
     #
     # Route providers included by a library (from reference.conf) can be excluded by an application
     # by using "" or null as the FQCN of the named entry, for example:
@@ -72,8 +72,10 @@ pekko.management {
     route-providers-read-only = true
   }
 
-  # Health checks for readiness and liveness
+  # Health checks for startup, readiness and liveness
   health-checks {
+    # When exposing health checks via Pekko Management, the path to expose startup checks on
+    startup-path = "startup"
     # When exposing health checks via Pekko Management, the path to expose readiness checks on
     readiness-path = "ready"
     # When exposing health checks via Pekko Management, the path to expose readiness checks on
@@ -90,6 +92,9 @@ pekko.management {
     #
     # Libraries and frameworks that contribute checks are expected to add their own checks to their reference.conf.
     # Applications can add their own checks to application.conf.
+    startup-checks {
+
+    }
     readiness-checks {
 
     }

--- a/management/src/main/scala/org/apache/pekko/management/HealthCheckRoutes.scala
+++ b/management/src/main/scala/org/apache/pekko/management/HealthCheckRoutes.scala
@@ -49,6 +49,11 @@ private[pekko] class HealthCheckRoutes(system: ExtendedActorSystem) extends Mana
 
   override def routes(mrps: ManagementRouteProviderSettings): Route = {
     concat(
+      path(PathMatchers.separateOnSlashes(settings.startupPath)) {
+        get {
+          onComplete(healthChecks.startupResult())(healthCheckResponse)
+        }
+      },
       path(PathMatchers.separateOnSlashes(settings.readinessPath)) {
         get {
           onComplete(healthChecks.readyResult())(healthCheckResponse)

--- a/management/src/main/scala/org/apache/pekko/management/ManagementLogMarker.scala
+++ b/management/src/main/scala/org/apache/pekko/management/ManagementLogMarker.scala
@@ -41,6 +41,12 @@ object ManagementLogMarker {
     LogMarker("pekkoManagementBound", Map(Properties.HttpAddress -> boundAddress))
 
   /**
+   * Marker "pekkoStartupCheckFailed" of log event when a startup check fails.
+   */
+  val startupCheckFailed: LogMarker =
+    LogMarker("pekkoStartupCheckFailed")
+
+  /**
    * Marker "pekkoReadinessCheckFailed" of log event when a readiness check fails.
    */
   val readinessCheckFailed: LogMarker =

--- a/management/src/main/scala/org/apache/pekko/management/scaladsl/HealthChecks.scala
+++ b/management/src/main/scala/org/apache/pekko/management/scaladsl/HealthChecks.scala
@@ -40,6 +40,16 @@ object HealthChecks {
 abstract class HealthChecks {
 
   /**
+   * Returns Future(true) if the system has started
+   */
+  def startup(): Future[Boolean]
+
+  /**
+   * Returns Future(result) containing the system's startup result
+   */
+  def startupResult(): Future[Either[String, Unit]]
+
+  /**
    * Returns Future(true) if the system is ready to receive user traffic
    */
   def ready(): Future[Boolean]
@@ -61,6 +71,23 @@ abstract class HealthChecks {
    */
   def aliveResult(): Future[Either[String, Unit]]
 }
+
+object StartupCheckSetup {
+
+  /**
+   * Programmatic definition of startup checks
+   */
+  def apply(createHealthChecks: ActorSystem => immutable.Seq[HealthChecks.HealthCheck]): StartupCheckSetup = {
+    new StartupCheckSetup(createHealthChecks)
+  }
+
+}
+
+/**
+ * Setup for startup checks, constructor is *Internal API*, use factories in [[StartupCheckSetup]]
+ */
+final class StartupCheckSetup private (
+    val createHealthChecks: ActorSystem => immutable.Seq[HealthChecks.HealthCheck]) extends Setup
 
 object ReadinessCheckSetup {
 

--- a/management/src/test/scala/org/apache/pekko/management/HealthCheckSettingsSpec.scala
+++ b/management/src/test/scala/org/apache/pekko/management/HealthCheckSettingsSpec.scala
@@ -13,32 +13,83 @@
 
 package org.apache.pekko.management
 
+import scala.annotation.nowarn
+import scala.concurrent.duration.DurationInt
+
 import com.typesafe.config.ConfigFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+@nowarn("msg=deprecated")
 class HealthCheckSettingsSpec extends AnyWordSpec with Matchers {
 
   "Health Check Settings" should {
     "filter out blank fqcn" in {
       HealthCheckSettings(ConfigFactory.parseString("""
+         startup-checks {
+          cluster-membership = ""
+         }
+         readiness-checks {}
+         liveness-checks {}
+         startup-path = ""
+         readiness-path = ""
+         liveness-path = ""
+         check-timeout = 1s
+        """)).startupChecks shouldEqual Nil
+      HealthCheckSettings(ConfigFactory.parseString("""
+         startup-checks {}
          readiness-checks {
           cluster-membership = ""
          }
          liveness-checks {}
+         startup-path = ""
          readiness-path = ""
          liveness-path = ""
          check-timeout = 1s
         """)).readinessChecks shouldEqual Nil
       HealthCheckSettings(ConfigFactory.parseString("""
+         startup-checks {}
          liveness-checks {
           cluster-membership = ""
          }
          readiness-checks {}
+         startup-path = ""
          readiness-path = ""
          liveness-path = ""
          check-timeout = 1s
-        """)).readinessChecks shouldEqual Nil
+        """)).livenessChecks shouldEqual Nil
+    }
+
+    "be creatable with primary constructor" in {
+      HealthCheckSettings.create(
+        startupChecks = java.util.Collections.emptyList(),
+        readinessChecks = java.util.Collections.emptyList(),
+        livenessChecks = java.util.Collections.emptyList(),
+        startupPath = "",
+        readinessPath = "",
+        livenessPath = "",
+        checkDuration = java.time.Duration.ofSeconds(1L))
+        .startupChecks shouldEqual Nil
+    }
+
+    "be creatable with legacy create method" in {
+      HealthCheckSettings.create(
+        readinessChecks = java.util.Collections.emptyList(),
+        livenessChecks = java.util.Collections.emptyList(),
+        readinessPath = "",
+        livenessPath = "",
+        checkDuration = java.time.Duration.ofSeconds(1L))
+        .startupChecks shouldEqual Nil
+    }
+
+    "be creatable with legacy constructor" in {
+      val healthCheckSettings = new HealthCheckSettings(
+        readinessChecks = Nil,
+        livenessChecks = Nil,
+        readinessPath = "",
+        livenessPath = "",
+        checkTimeout = 1.seconds)
+      healthCheckSettings.livenessChecks shouldEqual Nil
     }
   }
 


### PR DESCRIPTION
Applying this PR will add startup checks, similar to the readiness and liveness checks. Startup probes reached GA in Kubernetes 1.20. I recognize that adding this feature in a compatible way might be an issue, any advice in that regard is welcome. :)