### PR TITLE
use org.testcontainers:consul

### DIFF
--- a/discovery-consul/src/test/scala/org/apache/pekko/cluster/bootstrap/discovery/ConsulDiscoverySpec.scala
+++ b/discovery-consul/src/test/scala/org/apache/pekko/cluster/bootstrap/discovery/ConsulDiscoverySpec.scala
@@ -17,7 +17,6 @@ import com.google.common.net.HostAndPort
 import com.orbitz.consul.Consul
 import com.orbitz.consul.model.catalog.ImmutableCatalogRegistration
 import com.orbitz.consul.model.health.ImmutableService
-import com.pszymczyk.consul.{ ConsulProcess, ConsulStarterBuilder }
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.discovery.ServiceDiscovery.ResolvedTarget
@@ -28,6 +27,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{ Millis, Seconds, Span }
 import org.scalatest.wordspec.AnyWordSpecLike
+import org.testcontainers.consul.ConsulContainer
 
 import java.net.InetAddress
 import scala.concurrent.duration._
@@ -39,12 +39,15 @@ class ConsulDiscoverySpec
     with TestKitBase
     with ScalaFutures {
 
-  private val consul: ConsulProcess = ConsulStarterBuilder.consulStarter().withHttpPort(8500).build().start()
+  private val consul = new ConsulContainer("hashicorp/consul:1.15")
+  consul.start()
 
   "Consul Discovery" should {
     "work for defaults" in {
       val consulAgent =
-        Consul.builder().withHostAndPort(HostAndPort.fromParts(consul.getAddress, consul.getHttpPort)).build()
+        Consul.builder()
+          .withHostAndPort(HostAndPort.fromParts(consul.getHost, consul.getMappedPort(8500)))
+          .build()
       consulAgent
         .catalogClient()
         .register(

--- a/discovery-consul/src/test/scala/org/apache/pekko/cluster/bootstrap/discovery/ConsulDiscoverySpec.scala
+++ b/discovery-consul/src/test/scala/org/apache/pekko/cluster/bootstrap/discovery/ConsulDiscoverySpec.scala
@@ -81,8 +81,8 @@ class ConsulDiscoverySpec
         resolved.addresses should contain(
           ResolvedTarget(
             host = "127.0.0.1",
-          port = Some(1234),
-          address = Some(InetAddress.getByName("127.0.0.1"))))
+            port = Some(1234),
+            address = Some(InetAddress.getByName("127.0.0.1"))))
       } finally {
         testSystem.terminate()
       }

--- a/discovery-consul/src/test/scala/org/apache/pekko/cluster/bootstrap/discovery/ConsulDiscoverySpec.scala
+++ b/discovery-consul/src/test/scala/org/apache/pekko/cluster/bootstrap/discovery/ConsulDiscoverySpec.scala
@@ -46,7 +46,7 @@ class ConsulDiscoverySpec
     "work for defaults" in {
       val consulAgent =
         Consul.builder()
-          .withHostAndPort(HostAndPort.fromParts(consul.getHost, consul.getMappedPort(8500)))
+          .withHostAndPort(HostAndPort.fromParts(consul.getHost(), consul.getFirstMappedPort()))
           .build()
       consulAgent
         .catalogClient()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -69,7 +69,7 @@ object Dependencies {
     "org.apache.pekko" %% "pekko-actor" % pekkoVersion,
     "org.apache.pekko" %% "pekko-discovery" % pekkoVersion,
     "com.orbitz.consul" % "consul-client" % "1.5.3",
-    "com.pszymczyk.consul" % "embedded-consul" % "2.2.1" % Test,
+    "org.testcontainers" % "consul" % "1.20.1" % Test,
     "org.scalatest" %% "scalatest" % scalaTestVersion % Test,
     "org.apache.pekko" %% "pekko-testkit" % pekkoVersion % Test,
     "org.apache.pekko" %% "pekko-slf4j" % pekkoVersion % Test,


### PR DESCRIPTION
Host and Port for client are based on example in https://java.testcontainers.org/modules/consul/

The biggest issue with the change is the docker container for Consul has a non-deterministic port. So we need to construct a config with the mapped port.

Fixes #296 