### PR TITLE
Create HealthCheckSettingsCheck.scala

### DIFF
--- a/management/src/test/scala/doc/org/apache/pekko/management/HealthCheckSettingsCheck.scala
+++ b/management/src/test/scala/doc/org/apache/pekko/management/HealthCheckSettingsCheck.scala
@@ -22,8 +22,8 @@ import org.apache.pekko.management.HealthCheckSettings
 import scala.concurrent.duration.DurationInt
 
 /**
-  * Compile checks deliberately placed in a non-standard pekko package.
-  */ 
+ * Compile checks deliberately placed in a non-standard pekko package.
+ */
 object HealthCheckSettingsCheck {
   val settings = new HealthCheckSettings(
     Seq.empty,

--- a/management/src/test/scala/doc/org/apache/pekko/management/HealthCheckSettingsCheck.scala
+++ b/management/src/test/scala/doc/org/apache/pekko/management/HealthCheckSettingsCheck.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package doc.org.apache.pekko.management
+
+import org.apache.pekko.management.HealthCheckSettings
+
+import scala.concurrent.duration.DurationInt
+
+/**
+  * Compile checks deliberately placed in a non-standard pekko package.
+  */ 
+object HealthCheckSettingsCheck {
+  val settings = new HealthCheckSettings(
+    Seq.empty,
+    Seq.empty,
+    "",
+    "",
+    0.seconds
+  )
+}


### PR DESCRIPTION
relates to #293 - shows what could be broken if we make the HealthCheckSettingsCheck constructor non-public

I have no objection to making constructors that don't have exactly these 5 params non-public - eg package private - but I think this constructor or its equivalent after #293 should continue to be public.

```
HealthCheckSettings(
    val readinessChecks: immutable.Seq[NamedHealthCheck],
    val livenessChecks: immutable.Seq[NamedHealthCheck],
    val readinessPath: String,
    val livenessPath: String,
    val checkTimeout: FiniteDuration)
``` 