### PR TITLE
Kubernetes Service Discovery Custom Settings

### DIFF
--- a/discovery-kubernetes-api/src/main/scala/org/apache/pekko/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/org/apache/pekko/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
@@ -96,13 +96,16 @@ object KubernetesApiServiceDiscovery {
  * An alternative implementation that uses the Kubernetes API. The main advantage of this method is that it allows
  * you to define readiness/health checks that don't affect the bootstrap mechanism.
  */
-class KubernetesApiServiceDiscovery(implicit system: ActorSystem) extends ServiceDiscovery {
+class KubernetesApiServiceDiscovery(providedSettings: Option[Settings] = None)(
+    implicit system: ActorSystem) extends ServiceDiscovery {
 
   import system.dispatcher
 
   private val http = Http()
 
-  private val settings = Settings(system)
+  def this(system: ActorSystem) = this(None)(system)
+
+  private val settings = providedSettings.getOrElse(Settings(system))
 
   private val log = Logging(system, getClass)(LogSource.fromClass)
 

--- a/discovery-kubernetes-api/src/main/scala/org/apache/pekko/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/org/apache/pekko/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
@@ -96,16 +96,14 @@ object KubernetesApiServiceDiscovery {
  * An alternative implementation that uses the Kubernetes API. The main advantage of this method is that it allows
  * you to define readiness/health checks that don't affect the bootstrap mechanism.
  */
-class KubernetesApiServiceDiscovery(providedSettings: Option[Settings] = None)(
+class KubernetesApiServiceDiscovery(settings: Settings)(
     implicit system: ActorSystem) extends ServiceDiscovery {
 
   import system.dispatcher
 
   private val http = Http()
 
-  def this(system: ActorSystem) = this(None)(system)
-
-  private val settings = providedSettings.getOrElse(Settings(system))
+  def this()(implicit system: ActorSystem) = this(Settings(system))
 
   private val log = Logging(system, getClass)(LogSource.fromClass)
 

--- a/discovery-kubernetes-api/src/main/scala/org/apache/pekko/discovery/kubernetes/Settings.scala
+++ b/discovery-kubernetes-api/src/main/scala/org/apache/pekko/discovery/kubernetes/Settings.scala
@@ -20,9 +20,9 @@ import com.typesafe.config.Config
 
 import org.apache.pekko.util.OptionConverters._
 
-final class Settings(configNamespace: Option[String], system: ExtendedActorSystem) extends Extension {
+final class Settings(kubernetesApi: Config) extends Extension {
 
-  def this(system: ExtendedActorSystem) = this(None, system)
+  def this(system: ExtendedActorSystem) = this(system.settings.config.getConfig("pekko.discovery.kubernetes-api"))
 
   /**
    * Copied from PekkoManagementSettings, which we don't depend on.
@@ -36,14 +36,6 @@ final class Settings(configNamespace: Option[String], system: ExtendedActorSyste
     def optDefinedValue(key: String): Option[String] =
       if (hasDefined(key)) Some(config.getString(key)) else None
   }
-
-  private val defaultConfig = system.settings.config.getConfig("pekko.discovery.kubernetes-api")
-
-  private val kubernetesApi =
-    configNamespace match {
-      case Some(namespace) => system.settings.config.getConfig(namespace).withFallback(defaultConfig)
-      case _               => defaultConfig
-    }
 
   val apiCaPath: String =
     kubernetesApi.getString("api-ca-path")

--- a/discovery-kubernetes-api/src/test/scala/org/apache/pekko/discovery/kubernetes/KubernetesApiServiceDiscoverySpec.scala
+++ b/discovery-kubernetes-api/src/test/scala/org/apache/pekko/discovery/kubernetes/KubernetesApiServiceDiscoverySpec.scala
@@ -203,9 +203,8 @@ class KubernetesApiServiceDiscoverySpec extends AnyWordSpec with Matchers {
 
   "The discovery loading mechanism" should {
     "allow loading kubernetes-api discovery even if it is not the default" in {
-      implicit val system = ActorSystem()
+      val system = ActorSystem()
       // #kubernetes-api-discovery
-      val d = new KubernetesApiServiceDiscovery()
       val discovery = Discovery(system).loadServiceDiscovery("kubernetes-api")
       // #kubernetes-api-discovery
       discovery shouldBe a[KubernetesApiServiceDiscovery]

--- a/discovery-kubernetes-api/src/test/scala/org/apache/pekko/discovery/kubernetes/KubernetesApiServiceDiscoverySpec.scala
+++ b/discovery-kubernetes-api/src/test/scala/org/apache/pekko/discovery/kubernetes/KubernetesApiServiceDiscoverySpec.scala
@@ -203,8 +203,9 @@ class KubernetesApiServiceDiscoverySpec extends AnyWordSpec with Matchers {
 
   "The discovery loading mechanism" should {
     "allow loading kubernetes-api discovery even if it is not the default" in {
-      val system = ActorSystem()
+      implicit val system = ActorSystem()
       // #kubernetes-api-discovery
+      val d = new KubernetesApiServiceDiscovery()
       val discovery = Discovery(system).loadServiceDiscovery("kubernetes-api")
       // #kubernetes-api-discovery
       discovery shouldBe a[KubernetesApiServiceDiscovery]


### PR DESCRIPTION
Closes #311 

- Added configNamespace in Kubernetes settings object, so that users can create different settings based on config path

- Added "Settings" object to KubernetesApiServiceDiscovery constructor so that users are able to provide their different settings for discovery