### PR TITLE
use PekkoCoreDependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,6 @@ import com.typesafe.sbt.packager.docker.{ Cmd, ExecCmd }
 import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCheckResolver
 import sbt.Keys.parallelExecution
 
-ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
 ThisBuild / versionScheme := Some(VersionScheme.SemVerSpec)
 sourceDistName := "apache-pekko-management"
 sourceDistIncubating := false
@@ -27,8 +26,8 @@ ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 inThisBuild(Def.settings(
   Global / onLoad := {
     sLog.value.info(
-      s"Building Pekko Management ${version.value} against Pekko ${Dependencies
-          .pekkoVersion} and Pekko HTTP ${Dependencies.pekkoHttpVersion} on Scala ${(root / scalaVersion).value}")
+      s"Building Pekko Management ${version.value} against Pekko ${PekkoCoreDependency
+          .version} and Pekko HTTP ${PekkoHttpDependency.version} on Scala ${(root / scalaVersion).value}")
     (Global / onLoad).value
   }))
 
@@ -298,7 +297,7 @@ lazy val docs = project
       "canonical.base_url" -> "https://pekko.apache.org/docs/pekko-management/1.0",
       "scaladoc.base_url" -> s"https://pekko.apache.org/api/pekko-management/1.0/",
       "scala.binary.version" -> scalaBinaryVersion.value,
-      "pekko.version" -> Dependencies.pekkoVersion,
+      "pekko.version" -> PekkoCoreDependency.version,
       "extref.pekko.base_url" -> s"https://pekko.apache.org/docs/pekko/${Dependencies.pekkoBinaryVersion}/%s",
       "scaladoc.pekko.base_url" -> s"https://pekko.apache.org/api/pekko/${Dependencies.pekkoBinaryVersion}/",
       "extref.pekko-http.base_url" -> s"https://pekko.apache.org/docs/pekko-http/${Dependencies.pekkoHttpBinaryVersion}/%s",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,9 +17,9 @@ object Dependencies {
   val crossScalaVersions = Seq(scala212Version, scala213Version, scala3Version)
 
   val pekkoVersion = PekkoCoreDependency.version
-  val pekkoBinaryVersion = pekkoVersion.take(3)
+  val pekkoBinaryVersion = PekkoCoreDependency.default.link
   val pekkoHttpVersion = PekkoHttpDependency.version
-  val pekkoHttpBinaryVersion = pekkoHttpVersion.take(3)
+  val pekkoHttpBinaryVersion = PekkoHttpDependency.default.link
 
   val scalaTestVersion = "3.2.19"
   val scalaTestPlusJUnitVersion = scalaTestVersion + ".0"


### PR DESCRIPTION
strange build issues with #338 - this cut back version should still give us most of the benefits of sbt-pekko-build and remove the need for the snapshots resolver