### PR TITLE
add back snapshot resolver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ commands := commands.value.filterNot { command =>
   }
 }
 
+ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
 ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 
 inThisBuild(Def.settings(


### PR DESCRIPTION
undoes part of #341 due to broken CI builds - eg https://github.com/apache/pekko-management/actions/runs/11528126927/job/32094832082

similar to https://github.com/apache/pekko-connectors/pull/877

I will try later to come up with a better fix but my main priority is to get the CI builds working again