### PR TITLE
switch to eclipse-temurin docker

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -178,7 +178,7 @@ lazy val leaseKubernetesIntTest = pekkoModule("lease-kubernetes-int-test")
     name := "pekko-lease-kubernetes-int-test",
     libraryDependencies := Dependencies.leaseKubernetesTest,
     version ~= (_.replace('+', '-')),
-    dockerBaseImage := "openjdk:8-jre-alpine",
+    dockerBaseImage := "eclipse-temurin:8-jre-alpine",
     dockerUpdateLatest := true,
     dockerCommands := dockerCommands.value.flatMap {
       case ExecCmd("ENTRYPOINT", args @ _*) => Seq(Cmd("ENTRYPOINT", args.mkString(" ")))
@@ -250,7 +250,7 @@ lazy val integrationTestAwsApiEcs = pekkoIntTestModule("aws-api-ecs")
     discoveryAwsApiAsync)
   .enablePlugins(JavaAppPackaging, AshScriptPlugin, DockerPlugin, NoPublish)
   .settings(
-    dockerBaseImage := "openjdk:11-jre-slim",
+    dockerBaseImage := "eclipse-temurin:11-jre-alpine",
     Docker / com.typesafe.sbt.SbtNativePackager.autoImport.packageName := "ecs-integration-test-app",
     Docker / version := "1.0")
 

--- a/integration-test/kubernetes-api-java/pom.xml
+++ b/integration-test/kubernetes-api-java/pom.xml
@@ -135,7 +135,7 @@
             <image>
               <name>integration-test-kubernetes-api:1.3.3.7</name>
               <build>
-                <from>openjdk:8-jre-alpine</from>
+                <from>eclipse-temurin:8-jre-alpine</from>
                 <ports>
                   <port>8080</port>
                   <port>7626</port>

--- a/integration-test/kubernetes-api/build.sbt
+++ b/integration-test/kubernetes-api/build.sbt
@@ -20,7 +20,7 @@ dockerCommands :=
   }
 
 dockerExposedPorts := Seq(8080, 7626, 7355)
-dockerBaseImage := "openjdk:8-jre-alpine"
+dockerBaseImage := "eclipse-temurin:8-jre-alpine"
 
 dockerCommands ++= Seq(
   Cmd("USER", "root"),

--- a/integration-test/kubernetes-dns/build.sbt
+++ b/integration-test/kubernetes-dns/build.sbt
@@ -19,7 +19,7 @@ dockerCommands :=
   }
 
 dockerExposedPorts := Seq(8080, 7626, 7355)
-dockerBaseImage := "openjdk:8-jre-alpine"
+dockerBaseImage := "eclipse-temurin:8-jre-alpine"
 
 dockerCommands ++= Seq(
   Cmd("USER", "root"),


### PR DESCRIPTION
openjdk docker images are deprecated and out of date

https://hub.docker.com/_/openjdk