### PR TITLE
protect 1.2.x branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -47,6 +47,18 @@ github:
         dismiss_stale_reviews: false
         require_code_owner_reviews: false
         required_approving_review_count: 1
+    1.2.x:
+      required_status_checks:
+        # strict means "Require branches to be up to date before merging".
+        strict: false
+        # contexts are the names of checks that must pass
+        contexts:
+          - Code is formatted
+          - Check headers
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: false
+        required_approving_review_count: 1
     1.1.x:
       required_status_checks:
         # strict means "Require branches to be up to date before merging".


### PR DESCRIPTION
* a 1.2.0 release is not urgent but we will probably eventually release one
* branching off 1.2.x means that we can start work on 2.0.0