### PR TITLE
Update reference to Fabric8 Maven Plugin

### DIFF
--- a/docs/src/main/paradox/kubernetes-deployment/building-using-maven.md
+++ b/docs/src/main/paradox/kubernetes-deployment/building-using-maven.md
@@ -1,6 +1,7 @@
 # Building using Maven
 
-There are a number of Maven plugins available for building and deploying Docker images. We're going to use [Fabric8](https://maven.fabric8.io/).
+There are a number of Maven plugins available for building and deploying Docker images. We're going to use [Fabric8 Maven Plugin](https://github.com/fabric8io/docker-maven-plugin).
+
 ### Git hash based version numbers
     
 There are a number of Maven plugins available for interacting with git, we recommend the 


### PR DESCRIPTION
Link Validator CI is failing.

It seems like Fabric8 has been discontinued but this link seems to be the only broken one so far.

https://fabric8.io/