### PR TITLE
Remove pull_request trigger from link-validator

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -3,7 +3,6 @@ name: Link Validator
 permissions: {}
 
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1'


### PR DESCRIPTION
We've been doing this in other Pekko repos.
The link validators are just brittle and the failures are rarely caused by PRs. The pre-existing links can just start failing.