### PR TITLE
Get token on every request and make fs calls async

### DIFF
--- a/lease-kubernetes/src/main/resources/reference.conf
+++ b/lease-kubernetes/src/main/resources/reference.conf
@@ -52,4 +52,19 @@ pekko.coordination.lease.kubernetes {
     # server that are required. If this timeout is hit then the lease *may* be taken due to the response being lost
     # on the way back from the API server but will be reported as not taken and can be safely retried.
     lease-operation-timeout = 5s
+
+    # Settings that are specific to retrying requests with 401 responses due to possible token rotation
+    token-rotation-retry {
+      # Number of total attempts to make
+      max-attempts = 5
+
+      # The minimum backoff to be used
+      min-backoff = 10 ms
+
+      # The maximum backoff to be used
+      max-backoff = 1 minute
+
+      # The random factor to be used
+      random-factor = 0.3
+    }
 }

--- a/lease-kubernetes/src/main/scala/org/apache/pekko/coordination/lease/kubernetes/internal/AbstractKubernetesApiImpl.scala
+++ b/lease-kubernetes/src/main/scala/org/apache/pekko/coordination/lease/kubernetes/internal/AbstractKubernetesApiImpl.scala
@@ -15,7 +15,7 @@ package org.apache.pekko.coordination.lease.kubernetes.internal
 
 import org.apache.pekko
 import pekko.Done
-import pekko.actor.ActorSystem
+import pekko.actor.{ ActorSystem, Scheduler }
 import pekko.annotation.InternalApi
 import pekko.coordination.lease.kubernetes.{ KubernetesApi, KubernetesSettings, LeaseResource }
 import pekko.coordination.lease.{ LeaseException, LeaseTimeoutException }
@@ -24,15 +24,16 @@ import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers.{ Authorization, OAuth2BearerToken }
 import pekko.http.scaladsl.unmarshalling.Unmarshal
 import pekko.http.scaladsl.{ ConnectionContext, Http, HttpExt, HttpsConnectionContext }
-import pekko.pattern.after
+import pekko.pattern.{ after, RetrySupport }
 import pekko.pki.kubernetes.PemManagersProvider
+import pekko.stream.scaladsl.{ FileIO, Keep, Sink }
+import pekko.util.ByteString
 
-import java.nio.charset.StandardCharsets
 import java.nio.file.{ Files, Paths }
 import java.security.{ KeyStore, SecureRandom }
 import javax.net.ssl.{ KeyManager, KeyManagerFactory, SSLContext, TrustManager }
 import scala.collection.immutable
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.control.NonFatal
 
 /**
@@ -66,12 +67,24 @@ import scala.util.control.NonFatal
 
   private lazy val clientSslContext: HttpsConnectionContext = ConnectionContext.httpsClient(sslContext)
 
-  protected val namespace: String =
-    settings.namespace.orElse(readConfigVarFromFilesystem(settings.namespacePath, "namespace")).getOrElse("default")
+  protected val namespace: Future[String] = {
+    settings.namespace match {
+      case Some(nSpace) => Future.successful(nSpace)
+      case _            =>
+        readConfigVarFromFilesystem(settings.namespacePath, "namespace").map(_.getOrElse("default"))(
+          ExecutionContext.parasitic)
+    }
+  }
 
   protected val scheme: String = if (settings.secure) "https" else "http"
-  private lazy val apiToken = readConfigVarFromFilesystem(settings.apiTokenPath, "api-token").getOrElse("")
-  private lazy val headers = if (settings.secure) immutable.Seq(Authorization(OAuth2BearerToken(apiToken))) else Nil
+  private[pekko] def apiToken() = readConfigVarFromFilesystem(settings.apiTokenPath, "api-token").map(
+    _.getOrElse(""))(ExecutionContext.parasitic)
+  private def headers() = if (settings.secure) {
+    apiToken().map { token =>
+      immutable.Seq(Authorization(OAuth2BearerToken(token)))
+    }(ExecutionContext.parasitic)
+  } else
+    Future.successful(Nil)
 
   log.debug("kubernetes access namespace: {}. Secure: {}", namespace, settings.secure)
 
@@ -79,7 +92,7 @@ import scala.util.control.NonFatal
 
   protected def getLeaseResource(name: String): Future[Option[LeaseResource]]
 
-  protected def pathForLease(name: String): Uri.Path
+  protected def pathForLease(name: String): Future[Uri.Path]
 
   override def readOrCreateLeaseResource(name: String): Future[LeaseResource] = {
     // TODO backoff retry
@@ -110,10 +123,9 @@ import scala.util.control.NonFatal
 
   private[pekko] def removeLease(name: String): Future[Done] = {
     for {
-      response <- makeRequest(
-        requestForPath(pathForLease(name), HttpMethods.DELETE),
-        s"Timed out removing lease [$name]. It is not known if the remove happened")
-
+      leasePath <- pathForLease(name)
+      request <- requestForPath(leasePath, HttpMethods.DELETE)
+      response <- makeRequest(request, s"Timed out removing lease [$name]. It is not known if the remove happened")
       result <- response.status match {
         case StatusCodes.OK =>
           log.debug("Lease deleted {}", name)
@@ -148,17 +160,34 @@ import scala.util.control.NonFatal
   protected def requestForPath(
       path: Uri.Path,
       method: HttpMethod = HttpMethods.GET,
-      entity: RequestEntity = HttpEntity.Empty): HttpRequest = {
+      entity: RequestEntity = HttpEntity.Empty): Future[HttpRequest] = {
     val uri = Uri.from(scheme = scheme, host = settings.apiServerHost, port = settings.apiServerPort).withPath(path)
-    HttpRequest(uri = uri, headers = headers, method = method, entity = entity)
+    headers().map { headers =>
+      HttpRequest(uri = uri, headers = headers, method = method, entity = entity)
+    }(ExecutionContext.parasitic)
+  }
+
+  private[pekko] def makeRawRequest(request: HttpRequest): Future[HttpResponse] = {
+    if (settings.secure)
+      http.singleRequest(request, clientSslContext)
+    else
+      http.singleRequest(request)
   }
 
   protected def makeRequest(request: HttpRequest, timeoutMsg: String): Future[HttpResponse] = {
-    val response =
-      if (settings.secure)
-        http.singleRequest(request, clientSslContext)
-      else
-        http.singleRequest(request)
+    // It's possible to legitimately get a 401 response due to kubernetes doing a token rotation
+    implicit val scheduler: Scheduler = system.scheduler
+    val response = RetrySupport.retry(
+      () => makeRawRequest(request: HttpRequest),
+      (response: HttpResponse, _: Throwable) => {
+        log.warning("Received status code 401 as response, retrying due to possible token rotation")
+        response.status == StatusCodes.Unauthorized
+      },
+      settings.tokenRetrySettings.maxAttempts,
+      settings.tokenRetrySettings.minBackoff,
+      settings.tokenRetrySettings.maxBackoff,
+      settings.tokenRetrySettings.randomFactor
+    )
 
     // make sure we always consume response body (in case of timeout)
     val strictResponse = response.flatMap(_.toStrict(settings.bodyReadTimeout))
@@ -169,22 +198,22 @@ import scala.util.control.NonFatal
     Future.firstCompletedOf(Seq(strictResponse, timeout))
   }
 
-  /**
-   * This uses blocking IO, and so should only be used to read configuration at startup.
-   */
-  protected def readConfigVarFromFilesystem(path: String, name: String): Option[String] = {
+  protected def readConfigVarFromFilesystem(path: String, name: String): Future[Option[String]] = {
     val file = Paths.get(path)
     if (Files.exists(file)) {
       try {
-        Some(new String(Files.readAllBytes(file), StandardCharsets.UTF_8))
+        FileIO.fromPath(file)
+          .toMat(Sink.fold(ByteString.empty)(_ ++ _))(Keep.right)
+          .run()
+          .map(bs => Some(bs.utf8String))(ExecutionContext.parasitic)
       } catch {
         case NonFatal(e) =>
           log.error(e, "Error reading {} from {}", name, path)
-          None
+          Future.successful(None)
       }
     } else {
       log.warning("Unable to read {} from {} because it doesn't exist.", name, path)
-      None
+      Future.successful(None)
     }
   }
 

--- a/lease-kubernetes/src/test/scala/org/apache/pekko/coordination/lease/kubernetes/NativeKubernetesApiSpec.scala
+++ b/lease-kubernetes/src/test/scala/org/apache/pekko/coordination/lease/kubernetes/NativeKubernetesApiSpec.scala
@@ -36,6 +36,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class NativeKubernetesApiSpec
@@ -71,7 +72,8 @@ class NativeKubernetesApiSpec
 
   val underTest = new NativeKubernetesApiImpl(system, settings) {
     // avoid touching slow CI filesystem
-    override protected def readConfigVarFromFilesystem(path: String, name: String): Option[String] = None
+    override protected def readConfigVarFromFilesystem(path: String, name: String): Future[Option[String]] =
+      Future.successful(None)
   }
   val leaseName = "lease-1"
   val client1 = "client-1"


### PR DESCRIPTION
Resolves: https://github.com/apache/pekko-management/issues/543

The core issue here is that getting the token is just a `lazy val` (and so are computing the headers) which means that after the first call the token is just cached indefintiely.

We can explore using a cache, albeit I do think that reading from a file should be fast/cheap enough that its not necessary and I don't think these API calls are a bottleneck. Can also write a test if requested