### PR TITLE
HTTP Client: use Java Runtime default trust store if ca-path is not set

### DIFF
--- a/management-cluster-bootstrap/src/main/resources/reference.conf
+++ b/management-cluster-bootstrap/src/main/resources/reference.conf
@@ -137,6 +137,8 @@ pekko.management {
 
       http-client {
         # set this to your HTTPS certificate path if you want to setup a HTTPS trust store
+        # if this is left empty, the default Java Runtime trust store will be used
+        # pekko-management-cluster-bootstrap 1.2.0 did not default to the Java Runtime trust store
         ca-path = ""
         # the TLS version to use when connecting to contact points
         tls-version = "TLSv1.2"

--- a/management-cluster-bootstrap/src/main/scala/org/apache/pekko/management/cluster/bootstrap/internal/HttpContactPointBootstrap.scala
+++ b/management-cluster-bootstrap/src/main/scala/org/apache/pekko/management/cluster/bootstrap/internal/HttpContactPointBootstrap.scala
@@ -62,6 +62,7 @@ private[bootstrap] object HttpContactPointBootstrap {
 
   private case object ProbeTick extends DeadLetterSuppression
   private val ProbingTimerKey = "probing-key"
+  private val DefaultTlsVersion = "TLSv1.2" // keep in sync with default in reference.conf
 
   def generateSSLContext(settings: ClusterBootstrapSettings): SSLContext = {
     val factory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
@@ -71,7 +72,8 @@ private[bootstrap] object HttpContactPointBootstrap {
     val km: Array[KeyManager] = factory.getKeyManagers
     val caPath = settings.contactPoint.httpClient.caPath.trim
     val tm: Array[TrustManager] = if (caPath.isEmpty) {
-      Array.empty
+      // null means use the default JVM trust store, which is what we want if no CA path is configured
+      None.orNull
     } else {
       val certificates = PemManagersProvider.loadCertificates(caPath)
       PemManagersProvider.buildTrustManagers(certificates)
@@ -101,8 +103,7 @@ private[bootstrap] class HttpContactPointBootstrap(
     with Timers
     with HttpBootstrapJsonProtocol {
 
-  import HttpContactPointBootstrap.ProbeTick
-  import HttpContactPointBootstrap.ProbingTimerKey
+  import HttpContactPointBootstrap._
 
   private val cluster = Cluster(context.system)
 
@@ -115,8 +116,12 @@ private[bootstrap] class HttpContactPointBootstrap(
 
   private implicit val sys: ActorSystem = context.system
 
+  private val useCustomSslContext: Boolean =
+    settings.contactPoint.httpClient.caPath.trim.nonEmpty ||
+    settings.contactPoint.httpClient.tlsVersion != DefaultTlsVersion
+
   private lazy val clientSslContext: HttpsConnectionContext =
-    ConnectionContext.httpsClient(HttpContactPointBootstrap.generateSSLContext(settings))
+    ConnectionContext.httpsClient(generateSSLContext(settings))
 
   private val http = Http()
 
@@ -142,7 +147,7 @@ private[bootstrap] class HttpContactPointBootstrap(
   override def receive = {
     case ProbeTick =>
       log.debug("Probing [{}] for seed nodes...", probeRequest.uri)
-      val reply = if (probeRequest.uri.scheme == "https") {
+      val reply = if (probeRequest.uri.scheme == "https" && useCustomSslContext) {
         http.singleRequest(probeRequest, settings = connectionPoolWithoutRetries,
           connectionContext = clientSslContext)
       } else {


### PR DESCRIPTION
cherry pick 11e6969b3c5f462184cc3ea290e3ae37660d7ed7 #639

* disable custom sslcontext is capath is empty

* Update HttpContactPointBootstrap.scala

* Update reference.conf