### PR TITLE
Add target branch for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "1.2.x"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Broken builds on 1.2.x due to old action versions