### PR TITLE
docs: add Alternative with Custom Resource Definition section to rolling-updates.md

### DIFF
--- a/docs/src/main/paradox/rolling-updates.md
+++ b/docs/src/main/paradox/rolling-updates.md
@@ -109,7 +109,7 @@ setting `pekko.rollingupdate.kubernetes.namespace` or by providing `KUBERNETES_N
 
 @@@ warning
 
-This extension uses the Kubernetes API to set the `pod-deletion-cost` annotation on its own pod. To be able to do that, it requires special permission to be able to `patch` the pod configuration. Each pod only needs access to the namespace they are in.
+This extension uses the Kubernetes API to set the `pod-deletion-cost` annotation on its own pod. To be able to do that, it requires special permission to be able to `patch` the pod configuration. Each pod only needs access to the namespace they are in. If this is a security concern in your environment you may instead use @ref:[Alternative with Custom Resource Definition](#alternative-with-custom-resource-definition).
 
 @@@
 
@@ -145,6 +145,56 @@ that gives the default service user this role in `<YOUR NAMESPACE>`.
 This RBAC example covers only the permissions needed for this `PodDeletionCost` extension specifically. However, usually you'll also be using @ref:[Kubernetes API](bootstrap/kubernetes-api.md) for discovery and bootstrap of your cluster, so you'll need to combine this with any other role required already configured, either by keeping them separately or merging them into a single role.
 
 @@@
+
+#### Alternative with Custom Resource Definition
+
+If it's a security concern in your environment to allow "patch" in RBAC as described above, you can instead use an
+intermediate Custom Resource Definition (CRD). Instead of updating the `controller.kubernetes.io/pod-deletion-cost`
+annotation directly it will update a `PodCost` custom resource and then you would have an operator that reconciles
+that and updates the pod-deletion-cost annotation of the pod resource.
+
+@@@ note
+
+You would have to write the Kubernetes operator that watches the `PodCost` resource and updates the
+`controller.kubernetes.io/pod-deletion-cost` annotation of the corresponding pod resource. This operator
+is not provided by Pekko.
+
+@@@
+
+Enable updates of custom resource with configuration:
+
+```
+pekko.rollingupdate.kubernetes.custom-resource.enabled = true
+```
+
+The `PodCost` CRD:
+
+@@snip [pod-cost.yml](/rolling-update-kubernetes/pod-cost.yml) {}
+
+The RBAC for the application to update the `PodCost` CR, instead of "patch" of the "pods" resources:
+
+```
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: podcost-access
+rules:
+  - apiGroups: ["pekko.apache.org"]
+    resources: ["podcosts"]
+    verbs: ["get", "create", "update", "delete", "list"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: podcost-access
+subjects:
+  - kind: User
+    name: system:serviceaccount:<YOUR NAMESPACE>:default
+roleRef:
+  kind: Role
+  name: podcost-access
+  apiGroup: rbac.authorization.k8s.io
+```
 
 ## app-version from Deployment
 


### PR DESCRIPTION
Bringing docs up to date with akka-management 1.4.1 which is available under the Apache License, v2.0