### PR TITLE
chore: Rewrite to scala3 syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
 version                                  = 3.11.1
-runner.dialect                           = scala213
+runner.dialect                           = scala213source3
 project.git                              = true
 style                                    = defaultWithAlign
 docstrings.style                         = Asterisk
@@ -75,3 +75,13 @@ project.excludeFilters = [
   "scripts/authors.scala"
 ]
 project.layout         = StandardConvention
+
+rewrite.scala3.convertToNewSyntax = true
+runner {
+  dialectOverride {
+    allowSignificantIndentation = false
+    allowAsForImportRename = false
+    allowStarWildcardImport = false
+    allowPostfixStarVarargSplices = false
+  }
+}

--- a/management-cluster-bootstrap/src/test/scala/org/apache/pekko/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
+++ b/management-cluster-bootstrap/src/test/scala/org/apache/pekko/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
@@ -110,7 +110,7 @@ class ClusterBootstrapDiscoveryBackoffIntegrationSpec extends AnyWordSpecLike wi
     val bootstrapB = ClusterBootstrap(systemB)
 
     val baseTime = System.currentTimeMillis()
-    case class DiscoveryRequest(time: Long, attempt: Int, res: Future[_]) {
+    case class DiscoveryRequest(time: Long, attempt: Int, res: Future[?]) {
       override def toString = s"DiscoveryRequest(${(time - baseTime).millis}, $attempt, $res)"
     }
     val resolveProbe = TestProbe()(systemA)

--- a/management-cluster-http/src/main/scala/org/apache/pekko/management/cluster/scaladsl/ClusterHttpManagementRoutes.scala
+++ b/management-cluster-http/src/main/scala/org/apache/pekko/management/cluster/scaladsl/ClusterHttpManagementRoutes.scala
@@ -144,7 +144,7 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementJsonProtocol {
     import pekko.stream.scaladsl.Source
     import scala.concurrent.{ ExecutionContext, Promise }
 
-    val eventClasses: Map[String, Class[_]] = Map(
+    val eventClasses: Map[String, Class[?]] = Map(
       "ClusterDomainEvent" -> classOf[ClusterEvent.ClusterDomainEvent],
       "MemberEvent" -> classOf[ClusterEvent.MemberEvent],
       "MemberJoined" -> classOf[ClusterEvent.MemberJoined],
@@ -171,7 +171,7 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementJsonProtocol {
         parameter("type".as[String].*) { providedEventTypes =>
           val classes =
             if (providedEventTypes.nonEmpty)
-              providedEventTypes.foldLeft(List.empty[Class[_]]) {
+              providedEventTypes.foldLeft(List.empty[Class[?]]) {
                 case (accum, eventType) =>
                   eventClasses.get(eventType).toList ::: accum
               }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -26,7 +26,7 @@ object Common extends AutoPlugin {
 
   val isScala3 = Def.setting(scalaBinaryVersion.value == "3")
 
-  override lazy val projectSettings: Seq[sbt.Def.Setting[_]] =
+  override lazy val projectSettings: Seq[sbt.Def.Setting[?]] =
     Seq(
       startYear := Some(2022),
       homepage := Some(url("https://pekko.apache.org/")),

--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -23,7 +23,7 @@ trait CopyrightHeader extends AutoPlugin {
 
   override def trigger: PluginTrigger = allRequirements
 
-  protected def headerMappingSettings: Seq[Def.Setting[_]] =
+  protected def headerMappingSettings: Seq[Def.Setting[?]] =
     Seq(Compile, Test).flatMap { config =>
       inConfig(config)(
         Seq(
@@ -35,9 +35,9 @@ trait CopyrightHeader extends AutoPlugin {
             HeaderFileType("template") -> cStyleComment)))
     }
 
-  override def projectSettings: Seq[Def.Setting[_]] = Def.settings(headerMappingSettings, additional)
+  override def projectSettings: Seq[Def.Setting[?]] = Def.settings(headerMappingSettings, additional)
 
-  def additional: Seq[Def.Setting[_]] =
+  def additional: Seq[Def.Setting[?]] =
     Def.settings(Compile / compile := {
         (Compile / headerCreate).value
         (Compile / compile).value


### PR DESCRIPTION
### Motivation
Let Scala 3 Community build compile pekko-management.

### Modification
Update `.scalafmt.conf` dialect to `scala213source3` and enable Scala 3 syntax rewrite rules (`rewrite.scala3.convertToNewSyntax`), then reformat all sources. Key changes:
- Wildcard type `_` → `?` (e.g. `Class[_]` → `Class[?]`)

### Result
Code is compatible with Scala 3 compiler when built with the community build.

### Tests
Not run - formatting only

### References
Refs apache/pekko#3048