### PR TITLE
Improve Scala 3.8 forward compatibility

### DIFF
--- a/discovery-aws-api-async/src/main/scala/org/apache/pekko/discovery/awsapi/ecs/AsyncEcsServiceDiscovery.scala
+++ b/discovery-aws-api-async/src/main/scala/org/apache/pekko/discovery/awsapi/ecs/AsyncEcsServiceDiscovery.scala
@@ -39,9 +39,9 @@ import software.amazon.awssdk.services.ecs.model.{ Tag => _, _ }
 @ApiMayChange
 class AsyncEcsServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
 
-  private[this] val config = system.settings.config.getConfig("pekko.discovery.aws-api-ecs-async")
-  private[this] val cluster = config.getString("cluster")
-  private[this] val tags = config
+  private val config = system.settings.config.getConfig("pekko.discovery.aws-api-ecs-async")
+  private val cluster = config.getString("cluster")
+  private val tags = config
     .getConfigList("tags")
     .asScala
     .map { tagConfig =>
@@ -51,13 +51,13 @@ class AsyncEcsServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
     }
     .toList
 
-  private[this] lazy val ecsClient = {
+  private lazy val ecsClient = {
     val conf = ClientOverrideConfiguration.builder().retryStrategy(DefaultRetryStrategy.doNotRetry()).build()
     val httpClient = NettyNioAsyncHttpClient.create()
     EcsAsyncClient.builder().overrideConfiguration(conf).httpClient(httpClient).build()
   }
 
-  private[this] implicit val ec: ExecutionContext = system.dispatcher
+  private implicit val ec: ExecutionContext = system.dispatcher
 
   override def lookup(lookup: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] =
     Future.firstCompletedOf(
@@ -94,7 +94,7 @@ object AsyncEcsServiceDiscovery {
       }
     } yield tasksWithTags
 
-  private[this] def listTaskArns(
+  private def listTaskArns(
       ecsClient: EcsAsyncClient,
       cluster: String,
       serviceName: String,
@@ -124,7 +124,7 @@ object AsyncEcsServiceDiscovery {
       }
     } yield taskArns
 
-  private[this] def describeTasks(ecsClient: EcsAsyncClient, cluster: String, taskArns: Seq[String])(
+  private def describeTasks(ecsClient: EcsAsyncClient, cluster: String, taskArns: Seq[String])(
       implicit ec: ExecutionContext): Future[Seq[Task]] =
     for {
       // Each DescribeTasksRequest can contain at most 100 task ARNs.

--- a/discovery-aws-api-async/src/main/scala/org/apache/pekko/discovery/awsapi/ecs/AsyncEcsTaskSetDiscovery.scala
+++ b/discovery-aws-api-async/src/main/scala/org/apache/pekko/discovery/awsapi/ecs/AsyncEcsTaskSetDiscovery.scala
@@ -87,10 +87,10 @@ class AsyncEcsTaskSetDiscovery(system: ActorSystem) extends ServiceDiscovery {
 @ApiMayChange
 object AsyncEcsTaskSetDiscovery {
 
-  private[this] case class TaskMetadata(TaskARN: String)
-  private[this] case class TaskSet(value: String) extends AnyVal
+  private case class TaskMetadata(TaskARN: String)
+  private case class TaskSet(value: String) extends AnyVal
 
-  private[this] implicit val orderFormat: RootJsonFormat[TaskMetadata] = jsonFormat1(TaskMetadata.apply)
+  private implicit val orderFormat: RootJsonFormat[TaskMetadata] = jsonFormat1(TaskMetadata.apply)
 
   private val ECS_CONTAINER_METADATA_URI_PATH = "ECS_CONTAINER_METADATA_URI"
 
@@ -112,7 +112,7 @@ object AsyncEcsTaskSetDiscovery {
     } yield tasks
 
   // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v3.html
-  private[this] def resolveTaskMetadata(httpClient: HttpExt)(
+  private def resolveTaskMetadata(httpClient: HttpExt)(
       implicit
       ec: ExecutionContext,
       mat: Materializer): Future[Option[TaskMetadata]] = {
@@ -132,13 +132,13 @@ object AsyncEcsTaskSetDiscovery {
     }
   }
 
-  private[this] def resolveTaskSet(ecsClient: EcsAsyncClient, cluster: String, taskArn: String)(
+  private def resolveTaskSet(ecsClient: EcsAsyncClient, cluster: String, taskArn: String)(
       implicit ec: ExecutionContext): Future[Option[TaskSet]] =
     ecsClient.describeTasks(
       DescribeTasksRequest.builder().cluster(cluster).tasks(taskArn).include(TaskField.TAGS).build()).asScala.map(
       _.tasks().asScala.headOption).map(_.map(task => TaskSet(task.startedBy())))
 
-  private[this] def listTaskArns(
+  private def listTaskArns(
       ecsClient: EcsAsyncClient,
       cluster: String,
       taskSet: TaskSet,
@@ -168,7 +168,7 @@ object AsyncEcsTaskSetDiscovery {
       }
     } yield taskArns
 
-  private[this] def describeTasks(ecsClient: EcsAsyncClient, cluster: String, taskArns: Seq[String])(
+  private def describeTasks(ecsClient: EcsAsyncClient, cluster: String, taskArns: Seq[String])(
       implicit ec: ExecutionContext): Future[Seq[Task]] =
     for {
       // Each DescribeTasksRequest can contain at most 100 task ARNs.

--- a/discovery-aws-api/src/main/scala/org/apache/pekko/discovery/awsapi/ecs/EcsServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/org/apache/pekko/discovery/awsapi/ecs/EcsServiceDiscovery.scala
@@ -45,10 +45,10 @@ final class EcsServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
     "`pekko-discovery-aws-api` is deprecated because it uses the AWS SDK v1, which is no longer maintained. " +
     "Consider switching to `pekko-discovery-aws-api-async`, which uses the AWS SDK v2 and is actively maintained.")
 
-  private[this] val config = system.settings.config.getConfig("pekko.discovery.aws-api-ecs")
-  private[this] val cluster = config.getString("cluster")
+  private val config = system.settings.config.getConfig("pekko.discovery.aws-api-ecs")
+  private val cluster = config.getString("cluster")
 
-  private[this] lazy val ecsClient = {
+  private lazy val ecsClient = {
     // we have our own retry/backoff mechanism, so we don't need EC2Client's in addition
     val clientConfiguration = new ClientConfiguration()
     clientConfiguration.setRetryPolicy(PredefinedRetryPolicies.NO_RETRY_POLICY)
@@ -63,7 +63,7 @@ final class EcsServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
     builder.build()
   }
 
-  private[this] implicit val ec: ExecutionContext = system.dispatcher
+  private implicit val ec: ExecutionContext = system.dispatcher
 
   override def lookup(query: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] =
     Future.firstCompletedOf(
@@ -114,7 +114,7 @@ object EcsServiceDiscovery {
     tasks
   }
 
-  @tailrec private[this] def listTaskArns(
+  @tailrec private def listTaskArns(
       ecsClient: AmazonECS,
       cluster: String,
       serviceName: String,
@@ -141,7 +141,7 @@ object EcsServiceDiscovery {
     }
   }
 
-  private[this] def describeTasks(ecsClient: AmazonECS, cluster: String, taskArns: Seq[String]): Seq[Task] =
+  private def describeTasks(ecsClient: AmazonECS, cluster: String, taskArns: Seq[String]): Seq[Task] =
     for {
       // Each DescribeTasksRequest can contain at most 100 task ARNs.
       group <- taskArns.grouped(100).toList

--- a/discovery-marathon-api/src/main/scala/org/apache/pekko/discovery/marathon/MarathonApiServiceDiscovery.scala
+++ b/discovery-marathon-api/src/main/scala/org/apache/pekko/discovery/marathon/MarathonApiServiceDiscovery.scala
@@ -87,8 +87,8 @@ class MarathonApiServiceDiscovery(implicit system: ActorSystem) extends ServiceD
   import MarathonApiServiceDiscovery._
   import system.dispatcher
 
-  private implicit val classLogSource: LogSource[Class[_]] = LogSource.fromClass
-  private val log = Logging(system, getClass: Class[_])
+  private implicit val classLogSource: LogSource[Class[?]] = LogSource.fromClass
+  private val log = Logging(system, getClass: Class[?])
 
   private val http = Http()
 

--- a/discovery-marathon-api/src/main/scala/org/apache/pekko/discovery/marathon/MarathonApiServiceDiscovery.scala
+++ b/discovery-marathon-api/src/main/scala/org/apache/pekko/discovery/marathon/MarathonApiServiceDiscovery.scala
@@ -87,7 +87,8 @@ class MarathonApiServiceDiscovery(implicit system: ActorSystem) extends ServiceD
   import MarathonApiServiceDiscovery._
   import system.dispatcher
 
-  private val log = Logging(system, getClass)(LogSource.fromClass)
+  private implicit val classLogSource: LogSource[Class[_]] = LogSource.fromClass
+  private val log = Logging(system, getClass: Class[_])
 
   private val http = Http()
 

--- a/integration-test/aws-api-ecs/src/main/scala/org/apache/pekko/cluster/bootstrap/EcsApiDemoApp.scala
+++ b/integration-test/aws-api-ecs/src/main/scala/org/apache/pekko/cluster/bootstrap/EcsApiDemoApp.scala
@@ -44,7 +44,7 @@ object EcsApiDemoApp {
     ClusterBootstrap(system).start()
   }
 
-  private[this] def getPrivateAddressOrExit: InetAddress =
+  private def getPrivateAddressOrExit: InetAddress =
     AsyncEcsDiscovery.getContainerAddress match {
       case Left(error) =>
         System.err.println(s"$error Halting.")

--- a/lease-kubernetes/src/main/scala/org/apache/pekko/coordination/lease/kubernetes/internal/AbstractKubernetesApiImpl.scala
+++ b/lease-kubernetes/src/main/scala/org/apache/pekko/coordination/lease/kubernetes/internal/AbstractKubernetesApiImpl.scala
@@ -47,8 +47,8 @@ import scala.util.control.NonFatal
   import system.dispatcher
 
   protected implicit val sys: ActorSystem = system
-  private implicit val classLogSource: LogSource[Class[_]] = LogSource.fromClass
-  protected val log: LoggingAdapter = Logging(system, getClass: Class[_])
+  private implicit val classLogSource: LogSource[Class[?]] = LogSource.fromClass
+  protected val log: LoggingAdapter = Logging(system, getClass: Class[?])
   private val http: HttpExt = Http()(system)
 
   private lazy val sslContext: SSLContext = {

--- a/lease-kubernetes/src/main/scala/org/apache/pekko/coordination/lease/kubernetes/internal/AbstractKubernetesApiImpl.scala
+++ b/lease-kubernetes/src/main/scala/org/apache/pekko/coordination/lease/kubernetes/internal/AbstractKubernetesApiImpl.scala
@@ -47,7 +47,8 @@ import scala.util.control.NonFatal
   import system.dispatcher
 
   protected implicit val sys: ActorSystem = system
-  protected val log: LoggingAdapter = Logging(system, getClass)(LogSource.fromClass)
+  private implicit val classLogSource: LogSource[Class[_]] = LogSource.fromClass
+  protected val log: LoggingAdapter = Logging(system, getClass: Class[_])
   private val http: HttpExt = Http()(system)
 
   private lazy val sslContext: SSLContext = {

--- a/lease-kubernetes/src/test/scala/org/apache/pekko/coordination/lease/kubernetes/LeaseActorSpec.scala
+++ b/lease-kubernetes/src/test/scala/org/apache/pekko/coordination/lease/kubernetes/LeaseActorSpec.scala
@@ -237,7 +237,7 @@ class LeaseActorSpec
     }
 
     "heartbeat conflict should call lease lost callback" in new Test {
-      @volatile var callbackCalled: Option[Throwable] = _
+      @volatile var callbackCalled: Option[Throwable] = None
       acquireLease(reason => callbackCalled = reason)
       expectHeartBeat()
       granted.get() shouldEqual true
@@ -266,7 +266,7 @@ class LeaseActorSpec
 
     "heartbeat fail should call lease lost callback" in new Test {
       val k8sApiFailure = new LeaseException("Failed to communicate with API server")
-      @volatile var callbackCalled: Option[Throwable] = _
+      @volatile var callbackCalled: Option[Throwable] = None
       acquireLease(reason => callbackCalled = reason)
       expectHeartBeat()
       granted.get() shouldEqual true

--- a/management-cluster-bootstrap/src/main/scala/org/apache/pekko/management/cluster/bootstrap/ClusterBootstrap.scala
+++ b/management-cluster-bootstrap/src/main/scala/org/apache/pekko/management/cluster/bootstrap/ClusterBootstrap.scala
@@ -71,7 +71,7 @@ final class ClusterBootstrap(implicit system: ExtendedActorSystem) extends Exten
       .get
   }
 
-  private[this] val _selfContactPointUri: Promise[Uri] = Promise()
+  private val _selfContactPointUri: Promise[Uri] = Promise()
 
   // autostart if the extension is loaded through the config extension list
   private val autostart =

--- a/management-cluster-bootstrap/src/main/scala/org/apache/pekko/management/cluster/bootstrap/SelfAwareJoinDecider.scala
+++ b/management-cluster-bootstrap/src/main/scala/org/apache/pekko/management/cluster/bootstrap/SelfAwareJoinDecider.scala
@@ -32,7 +32,8 @@ import scala.concurrent.duration._
     system: ActorSystem,
     settings: ClusterBootstrapSettings) extends JoinDecider {
 
-  protected val log = Logging.withMarker(system, getClass)(LogSource.fromClass)
+  protected implicit val classLogSource: LogSource[Class[_]] = LogSource.fromClass
+  protected val log = Logging.withMarker(system, getClass: Class[_])
 
   /** Returns the current `selfContactPoints` as a String for logging, e.g. [127.0.0.1:64714]. */
   protected def contactPointString(contactPoint: (String, Int)): String =

--- a/management-cluster-bootstrap/src/main/scala/org/apache/pekko/management/cluster/bootstrap/SelfAwareJoinDecider.scala
+++ b/management-cluster-bootstrap/src/main/scala/org/apache/pekko/management/cluster/bootstrap/SelfAwareJoinDecider.scala
@@ -32,8 +32,8 @@ import scala.concurrent.duration._
     system: ActorSystem,
     settings: ClusterBootstrapSettings) extends JoinDecider {
 
-  protected implicit val classLogSource: LogSource[Class[_]] = LogSource.fromClass
-  protected val log = Logging.withMarker(system, getClass: Class[_])
+  protected implicit val classLogSource: LogSource[Class[?]] = LogSource.fromClass
+  protected val log = Logging.withMarker(system, getClass: Class[?])
 
   /** Returns the current `selfContactPoints` as a String for logging, e.g. [127.0.0.1:64714]. */
   protected def contactPointString(contactPoint: (String, Int)): String =

--- a/management-cluster-bootstrap/src/test/scala/org/apache/pekko/discovery/MockDiscovery.scala
+++ b/management-cluster-bootstrap/src/test/scala/org/apache/pekko/discovery/MockDiscovery.scala
@@ -49,8 +49,8 @@ object MockDiscovery {
 @InternalApi
 final class MockDiscovery(system: ActorSystem) extends ServiceDiscovery {
 
-  private implicit val classLogSource: LogSource[Class[_]] = LogSource.fromClass
-  private val log = Logging(system, getClass: Class[_])
+  private implicit val classLogSource: LogSource[Class[?]] = LogSource.fromClass
+  private val log = Logging(system, getClass: Class[?])
 
   override def lookup(query: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] = {
     MockDiscovery.data.get().get(query) match {

--- a/management-cluster-bootstrap/src/test/scala/org/apache/pekko/discovery/MockDiscovery.scala
+++ b/management-cluster-bootstrap/src/test/scala/org/apache/pekko/discovery/MockDiscovery.scala
@@ -49,7 +49,8 @@ object MockDiscovery {
 @InternalApi
 final class MockDiscovery(system: ActorSystem) extends ServiceDiscovery {
 
-  private val log = Logging(system, getClass)(LogSource.fromClass)
+  private implicit val classLogSource: LogSource[Class[_]] = LogSource.fromClass
+  private val log = Logging(system, getClass: Class[_])
 
   override def lookup(query: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] = {
     MockDiscovery.data.get().get(query) match {

--- a/management/src/main/scala/org/apache/pekko/management/scaladsl/PekkoManagement.scala
+++ b/management/src/main/scala/org/apache/pekko/management/scaladsl/PekkoManagement.scala
@@ -72,7 +72,8 @@ final class PekkoManagement(implicit private[pekko] val system: ExtendedActorSys
       "pekko-management-cluster-http"),
     logWarning = true)
 
-  private val log = Logging.withMarker(system, getClass)(LogSource.fromClass)
+  private implicit val classLogSource: LogSource[Class[_]] = LogSource.fromClass
+  private val log = Logging.withMarker(system, getClass: Class[_])
   val settings: PekkoManagementSettings = new PekkoManagementSettings(system.settings.config)
 
   import system.dispatcher

--- a/management/src/main/scala/org/apache/pekko/management/scaladsl/PekkoManagement.scala
+++ b/management/src/main/scala/org/apache/pekko/management/scaladsl/PekkoManagement.scala
@@ -72,8 +72,8 @@ final class PekkoManagement(implicit private[pekko] val system: ExtendedActorSys
       "pekko-management-cluster-http"),
     logWarning = true)
 
-  private implicit val classLogSource: LogSource[Class[_]] = LogSource.fromClass
-  private val log = Logging.withMarker(system, getClass: Class[_])
+  private implicit val classLogSource: LogSource[Class[?]] = LogSource.fromClass
+  private val log = Logging.withMarker(system, getClass: Class[?])
   val settings: PekkoManagementSettings = new PekkoManagementSettings(system.settings.config)
 
   import system.dispatcher

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -49,16 +49,21 @@ object Common extends AutoPlugin {
           "-unchecked",
           "-deprecation",
           "-release:17")
-        if (scalaVersion.value == Dependencies.scala213Version)
+        if (scalaBinaryVersion.value == "2.13")
           scalacOptionsBase ++: Seq(
             "-Werror",
             "-Wdead-code")
-        else if (scalaVersion.value == Dependencies.scala3Version)
+        else
           scalacOptionsBase ++: Seq(
             "-Werror",
-            "-Yfuture-lazy-vals")
-        else
-          scalacOptionsBase
+            "-Yfuture-lazy-vals",
+            "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s",
+            "-Wconf:msg=is deprecated for wildcard arguments of types:s",
+            "-Wconf:msg=The trailing ` _` for eta-expansion is unnecessary:s",
+            "-Wconf:msg=with as a type operator has been deprecated:s",
+            "-Wconf:msg=Unreachable case except for null:s",
+            "-Wconf:msg=is no longer supported for vararg splices:s",
+            "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s")
       },
       javacOptions ++= Seq(
         "-Xlint:unchecked"),

--- a/rolling-update-kubernetes/src/main/scala/org/apache/pekko/rollingupdate/kubernetes/PodDeletionCostAnnotator.scala
+++ b/rolling-update-kubernetes/src/main/scala/org/apache/pekko/rollingupdate/kubernetes/PodDeletionCostAnnotator.scala
@@ -67,7 +67,7 @@ import com.typesafe.config.Config
 
   Cluster(context.system).subscribe(context.self, classOf[ClusterEvent.MemberUp], classOf[ClusterEvent.MemberRemoved])
 
-  def receive: Receive = idle(0, SortedSet.empty[Member], 0)
+  def receive: Receive = idle(0, SortedSet.empty(Member.ageOrdering), 0)
 
   private def idle(deletionCost: Int, membersByAgeDesc: SortedSet[Member], retryNr: Int): Receive = {
     case cs @ ClusterEvent.CurrentClusterState(members, _, _, _, _) =>

--- a/rolling-update-kubernetes/src/main/scala/org/apache/pekko/rollingupdate/kubernetes/PodDeletionCostAnnotator.scala
+++ b/rolling-update-kubernetes/src/main/scala/org/apache/pekko/rollingupdate/kubernetes/PodDeletionCostAnnotator.scala
@@ -67,7 +67,7 @@ import com.typesafe.config.Config
 
   Cluster(context.system).subscribe(context.self, classOf[ClusterEvent.MemberUp], classOf[ClusterEvent.MemberRemoved])
 
-  def receive: Receive = idle(0, SortedSet.empty(Member.ageOrdering), 0)
+  def receive: Receive = idle(0, SortedSet.empty[Member], 0)
 
   private def idle(deletionCost: Int, membersByAgeDesc: SortedSet[Member], retryNr: Int): Receive = {
     case cs @ ClusterEvent.CurrentClusterState(members, _, _, _, _) =>


### PR DESCRIPTION
## Summary
- Replace `private[this]` with `private` in 22 locations (deprecated in Scala 3.8)
- Replace `= _` with `= None` for Option vars (2 locations, deprecated in 3.8)
- Fix context bounds compatibility for Logging calls: add local implicit `LogSource[Class[_]]` with type casts (5 locations)
- Fix `SortedSet.empty` ambiguity with explicit type parameter (1 location)
- Refactor scalacOptions to use `scalaBinaryVersion` for broader version compatibility
- Add `-Wconf` suppressions for warnings requiring Scala 3-only syntax
- Zero new warnings when compiled with Scala 3.8.4, while maintaining full cross-compilation with Scala 2.13 and 3.3.x

## Test plan
- [x] Verified clean compilation with Scala 3.8.4 (zero new warnings)
- [ ] CI passes on Scala 2.13 and 3.3.x