### PR TITLE
build: fix sbt lint warnings by excluding unused keys

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -338,6 +338,7 @@ lazy val docs = project
     Preprocess / preprocessRules := Seq(
       ("\\.java\\.scala".r, _ => ".java")),
     previewPath := (Paradox / siteSubdirName).value,
+    Global / excludeLintKeys += previewPath,
     paradoxGroups := Map("Language" -> Seq("Java", "Scala")),
     Paradox / siteSubdirName := s"docs/pekko-management/${if (isSnapshot.value) "snapshot" else version.value}",
     Compile / paradoxProperties ++= Map(

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -26,6 +26,9 @@ object Common extends AutoPlugin {
 
   val isScala3 = Def.setting(scalaBinaryVersion.value == "3")
 
+  override def globalSettings =
+    Seq(excludeLintKeys ++= Set(autoAPIMappings, projectInfoVersion))
+
   override lazy val projectSettings: Seq[sbt.Def.Setting[?]] =
     Seq(
       startYear := Some(2022),


### PR DESCRIPTION
### Motivation
sbt lint reported 51 unused keys across sub-projects: `autoAPIMappings` and `projectInfoVersion` in 25+ modules, plus `previewPath` in docs.

### Modification
- Add `autoAPIMappings` and `projectInfoVersion` to `excludeLintKeys` in `project/Common.scala` globalSettings
- Add `Global / excludeLintKeys += previewPath` in `build.sbt` docs project

### Result
sbt load no longer reports any unused key warnings.

### Tests
- `sbt "clean; compile"` - zero warnings

### References
None - build configuration cleanup