### PR TITLE
fix: Scala 3.9 context bound compat for SortedSet.empty

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -59,14 +59,13 @@ object Common extends AutoPlugin {
         else
           scalacOptionsBase ++: Seq(
             "-Werror",
-            "-Yfuture-lazy-vals",
             "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s",
             "-Wconf:msg=is deprecated for wildcard arguments of types:s",
             "-Wconf:msg=The trailing ` _` for eta-expansion is unnecessary:s",
             "-Wconf:msg=with as a type operator has been deprecated:s",
             "-Wconf:msg=Unreachable case except for null:s",
-            "-Wconf:msg=is no longer supported for vararg splices:s",
-            "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s")
+            "-Wconf:msg=is no longer supported for vararg splices:s") ++
+          (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)) Seq("-Yfuture-lazy-vals", "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s") else Seq.empty)
       },
       javacOptions ++= Seq(
         "-Xlint:unchecked"),

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -57,7 +57,8 @@ object Common extends AutoPlugin {
             "-Werror",
             "-Wdead-code")
         else
-          scalacOptionsBase ++: Seq(
+          scalacOptionsBase ++:
+          (Seq(
             "-Werror",
             "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s",
             "-Wconf:msg=is deprecated for wildcard arguments of types:s",
@@ -65,7 +66,9 @@ object Common extends AutoPlugin {
             "-Wconf:msg=with as a type operator has been deprecated:s",
             "-Wconf:msg=Unreachable case except for null:s",
             "-Wconf:msg=is no longer supported for vararg splices:s") ++
-          (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)) Seq("-Yfuture-lazy-vals", "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s") else Seq.empty)
+          (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9))
+             Seq("-Yfuture-lazy-vals", "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s")
+           else Seq.empty))
       },
       javacOptions ++= Seq(
         "-Xlint:unchecked"),

--- a/rolling-update-kubernetes/src/main/scala/org/apache/pekko/rollingupdate/kubernetes/PodDeletionCostAnnotator.scala
+++ b/rolling-update-kubernetes/src/main/scala/org/apache/pekko/rollingupdate/kubernetes/PodDeletionCostAnnotator.scala
@@ -67,7 +67,7 @@ import com.typesafe.config.Config
 
   Cluster(context.system).subscribe(context.self, classOf[ClusterEvent.MemberUp], classOf[ClusterEvent.MemberRemoved])
 
-  implicit val memberAgeOrdering: Ordering[Member] = Member.ageOrdering
+  private implicit val memberAgeOrdering: Ordering[Member] = Member.ageOrdering
   def receive: Receive = idle(0, SortedSet.empty, 0)
 
   private def idle(deletionCost: Int, membersByAgeDesc: SortedSet[Member], retryNr: Int): Receive = {

--- a/rolling-update-kubernetes/src/main/scala/org/apache/pekko/rollingupdate/kubernetes/PodDeletionCostAnnotator.scala
+++ b/rolling-update-kubernetes/src/main/scala/org/apache/pekko/rollingupdate/kubernetes/PodDeletionCostAnnotator.scala
@@ -67,7 +67,8 @@ import com.typesafe.config.Config
 
   Cluster(context.system).subscribe(context.self, classOf[ClusterEvent.MemberUp], classOf[ClusterEvent.MemberRemoved])
 
-  def receive: Receive = idle(0, SortedSet.empty(Member.ageOrdering), 0)
+  implicit val memberAgeOrdering: Ordering[Member] = Member.ageOrdering
+  def receive: Receive = idle(0, SortedSet.empty, 0)
 
   private def idle(deletionCost: Int, membersByAgeDesc: SortedSet[Member], retryNr: Int): Receive = {
     case cs @ ClusterEvent.CurrentClusterState(members, _, _, _, _) =>


### PR DESCRIPTION
### Motivation
Scala 3.9.0-RC1 changes context bound desugaring, making explicit `SortedSet.empty(Member.ageOrdering)` fail with a type mismatch error where the `Ordering` argument is incorrectly matched against the element type.

### Modification
Use `implicit val memberAgeOrdering: Ordering[Member] = Member.ageOrdering` and rely on implicit resolution for `SortedSet.empty` instead of passing the `Ordering` explicitly.

### Result
`rolling-update-kubernetes` module compiles cleanly with Scala 3.9.0-RC1.

### Tests
- `sbt "++3.9.0-RC1!; rolling-update-kubernetes/compile; rolling-update-kubernetes/Test/compile"` passes

### References
None - Scala 3.9 forward compatibility