### PR TITLE
refactor: upgrade JUnit Jupiter to 6.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,9 @@ ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 
 ThisBuild / javafmtFormatterCompatibleJavaVersion := 17
 
+ThisBuild / JupiterKeys.junitJupiterVersion := "6.1.0"
+ThisBuild / JupiterKeys.junitPlatformVersion := "6.1.0"
+
 ThisBuild / javafmt / excludeFilter := (javafmt / excludeFilter).value || new SimpleFileFilter(
   _.getCanonicalPath.contains(s"${java.io.File.separator}jdoc${java.io.File.separator}")
 )


### PR DESCRIPTION
## Motivation
JUnit 6 unifies version numbering across Platform, Jupiter, and Vintage components.

## Modification
Add JupiterKeys overrides for JUnit Jupiter and Platform 6.1.0.

## Result
All JUnit tests run on JUnit 6.1.0 (Java 17+ baseline).