### PR TITLE
refactor: remove deprecated HealthCheckSettings constructors (since 1.1.0)

### DIFF
--- a/management/src/main/mima-filters/1.0.0.backwards.excludes/remove-deprecated-healthcheck-settings.excludes
+++ b/management/src/main/mima-filters/1.0.0.backwards.excludes/remove-deprecated-healthcheck-settings.excludes
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Remove deprecated HealthCheckSettings constructor and factory (since 1.1.0)
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.management.HealthCheckSettings.create")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.management.HealthCheckSettings.this")

--- a/management/src/main/scala/org/apache/pekko/management/HealthCheckSettings.scala
+++ b/management/src/main/scala/org/apache/pekko/management/HealthCheckSettings.scala
@@ -89,24 +89,6 @@ object HealthCheckSettings {
       livenessPath,
       checkDuration.toScala)
 
-  /**
-   * Java API
-   */
-  @deprecated("Use create that takes `startupChecks` and `startupPath` parameters instead", "1.1.0")
-  def create(
-      readinessChecks: java.util.List[NamedHealthCheck],
-      livenessChecks: java.util.List[NamedHealthCheck],
-      readinessPath: String,
-      livenessPath: String,
-      checkDuration: java.time.Duration) =
-    new HealthCheckSettings(
-      Nil,
-      readinessChecks.asScala.toList,
-      livenessChecks.asScala.toList,
-      "",
-      readinessPath,
-      livenessPath,
-      checkDuration.toScala)
 }
 
 /**
@@ -126,25 +108,6 @@ final class HealthCheckSettings(
     val readinessPath: String,
     val livenessPath: String,
     val checkTimeout: FiniteDuration) {
-
-  @deprecated("Use constructor that takes `startupChecks` and `startupPath` parameters instead", "1.1.0")
-  def this(
-      readinessChecks: immutable.Seq[NamedHealthCheck],
-      livenessChecks: immutable.Seq[NamedHealthCheck],
-      readinessPath: String,
-      livenessPath: String,
-      checkTimeout: FiniteDuration
-  ) = {
-    this(
-      Nil,
-      readinessChecks,
-      livenessChecks,
-      "",
-      readinessPath,
-      livenessPath,
-      checkTimeout
-    )
-  }
 
   /**
    * Java API

--- a/management/src/test/java/org/apache/pekko/management/HealthCheckTest.java
+++ b/management/src/test/java/org/apache/pekko/management/HealthCheckTest.java
@@ -115,23 +115,6 @@ public class HealthCheckTest {
   }
 
   @Test
-  public void creatableThroughLegacyConstructor() throws Exception {
-    List<NamedHealthCheck> healthChecks =
-        List.of(new NamedHealthCheck("Ok", "org.apache.pekko.management.HealthCheckTest$Ok"));
-    HealthChecks checks =
-        new HealthChecks(
-            system,
-            HealthCheckSettings.create(
-                healthChecks, healthChecks, "ready", "alive", java.time.Duration.ofSeconds(1)));
-    assertEquals(true, checks.startupResult().toCompletableFuture().get().isSuccess());
-    assertEquals(true, checks.aliveResult().toCompletableFuture().get().isSuccess());
-    assertEquals(true, checks.readyResult().toCompletableFuture().get().isSuccess());
-    assertEquals(true, checks.startup().toCompletableFuture().get());
-    assertEquals(true, checks.alive().toCompletableFuture().get());
-    assertEquals(true, checks.ready().toCompletableFuture().get());
-  }
-
-  @Test
   public void throwsReturnsFailed() throws Exception {
     List<NamedHealthCheck> healthChecks =
         List.of(

--- a/management/src/test/scala/org/apache/pekko/management/HealthCheckSettingsSpec.scala
+++ b/management/src/test/scala/org/apache/pekko/management/HealthCheckSettingsSpec.scala
@@ -71,16 +71,6 @@ class HealthCheckSettingsSpec extends AnyWordSpec with Matchers {
         checkDuration = java.time.Duration.ofSeconds(1L))
         .startupChecks shouldEqual Nil
     }
-
-    "be creatable with legacy create method" in {
-      HealthCheckSettings.create(
-        readinessChecks = java.util.Collections.emptyList(),
-        livenessChecks = java.util.Collections.emptyList(),
-        readinessPath = "",
-        livenessPath = "",
-        checkDuration = java.time.Duration.ofSeconds(1L))
-        .startupChecks shouldEqual Nil
-    }
   }
 
 }

--- a/management/src/test/scala/org/apache/pekko/management/HealthCheckSettingsSpec.scala
+++ b/management/src/test/scala/org/apache/pekko/management/HealthCheckSettingsSpec.scala
@@ -81,16 +81,6 @@ class HealthCheckSettingsSpec extends AnyWordSpec with Matchers {
         checkDuration = java.time.Duration.ofSeconds(1L))
         .startupChecks shouldEqual Nil
     }
-
-    "be creatable with legacy constructor" in {
-      val healthCheckSettings = new HealthCheckSettings(
-        readinessChecks = Nil,
-        livenessChecks = Nil,
-        readinessPath = "",
-        livenessPath = "",
-        checkTimeout = 1.seconds)
-      healthCheckSettings.livenessChecks shouldEqual Nil
-    }
   }
 
 }


### PR DESCRIPTION
### Motivation
The legacy `HealthCheckSettings.create` overload and secondary constructor without `startupChecks`/`startupPath` parameters were deprecated since 1.1.0.

### Modification
Remove the deprecated `create` overload (5-arg version) and deprecated secondary constructor (5-arg version). Remove the corresponding test case for the legacy constructor.

### Result
Cleaner API with only the full constructor available that includes `startupChecks` and `startupPath`.

### Tests
Not run - trivial removal of deprecated overloads

### References
None - deprecated API cleanup