### PR TITLE
feat: add Scala 3.8.4 cross-compilation target

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,6 +20,7 @@ jobs:
         include:
           - { javaVersion: 17,  scalaVersion: 2.13, sbtOpts: '' }
           - { javaVersion: 17,  scalaVersion: 3.3,  sbtOpts: '' }
+          - { javaVersion: 17,  scalaVersion: 3.8,  sbtOpts: '' }
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -66,7 +66,7 @@ object Common extends AutoPlugin {
             "-Wconf:msg=with as a type operator has been deprecated:s",
             "-Wconf:msg=Unreachable case except for null:s",
             "-Wconf:msg=is no longer supported for vararg splices:s") ++
-          (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9))
+          (if (scalaVersion.value.startsWith("3.3."))
              Seq("-Yfuture-lazy-vals", "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s")
            else Seq.empty))
       },

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,8 @@ object Dependencies {
   // keep in sync with .github/workflows/unit-tests.yml
   val scala213Version = "2.13.18"
   val scala3Version = "3.3.8"
-  val crossScalaVersions = Seq(scala213Version, scala3Version)
+  val scala3NextVersion = "3.8.4"
+  val crossScalaVersions = Seq(scala213Version, scala3Version, scala3NextVersion)
 
   val pekkoVersion = PekkoCoreDependency.version
   val pekkoBinaryVersion = PekkoCoreDependency.default.link


### PR DESCRIPTION
### Motivation
Ensure pekko-management compiles and tests pass on the next Scala 3 release line (3.8.x), preparing for future Scala 3.9.x compatibility.

### Modification
- Add `scala3NextVersion = "3.8.4"` to Dependencies.scala
- Add Scala 3.8.4 to `crossScalaVersions`
- Add Scala 3.8 to CI matrix in unit-tests.yml

### Result
CI now compiles and tests against Scala 2.13, 3.3, and 3.8. Publishing continues with Scala 3.3.8.

### Tests
CI will validate

### References
None - proactive compatibility testing