### PR TITLE
fix: fix compilation warnings across all Scala versions

### DIFF
--- a/management/src/test/java/org/apache/pekko/management/HealthCheckTest.java
+++ b/management/src/test/java/org/apache/pekko/management/HealthCheckTest.java
@@ -114,6 +114,7 @@ public class HealthCheckTest {
     assertEquals(true, checks.ready().toCompletableFuture().get());
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void creatableThroughLegacyConstructor() throws Exception {
     List<NamedHealthCheck> healthChecks =


### PR DESCRIPTION
### Motivation
A Java deprecation note was present in `HealthCheckTest.java` when compiling with `-Xlint:deprecation`. The `creatableThroughLegacyConstructor` test intentionally uses the deprecated `HealthCheckSettings.create` overload (the 5-argument variant without startup checks) to verify backward compatibility.

### Modification
- Add `@SuppressWarnings("deprecation")` to the `creatableThroughLegacyConstructor` test method in `HealthCheckTest.java`, since it intentionally exercises the deprecated API for backward compatibility testing.

### Result
Clean compilation with zero warnings and zero deprecation notes across all Scala cross-build versions (2.13.18, 3.3.8, 3.8.4).

### Tests
- `sbt +test:compile` - all versions pass with no warnings

### References
None - code quality improvement