### PR TITLE
refactor: replace deprecated extends App with explicit main method

### DIFF
--- a/integration-test/aws-api-ec2/src/main/scala/org/apache/pekko/cluster/bootstrap/Ec2DemoApp.scala
+++ b/integration-test/aws-api-ec2/src/main/scala/org/apache/pekko/cluster/bootstrap/Ec2DemoApp.scala
@@ -18,12 +18,14 @@ import pekko.actor.ActorSystem
 import pekko.management.cluster.bootstrap.ClusterBootstrap
 import pekko.management.scaladsl.PekkoManagement
 
-object Ec2DemoApp extends App {
+object Ec2DemoApp {
+  def main(args: Array[String]): Unit = {
 
-  implicit val system: ActorSystem = ActorSystem("demo")
+    implicit val system: ActorSystem = ActorSystem("demo")
 
-  PekkoManagement(system).start()
+    PekkoManagement(system).start()
 
-  ClusterBootstrap(system).start()
+    ClusterBootstrap(system).start()
 
+  }
 }

--- a/integration-test/dns-api-mesos/src/main/scala/org/apache/pekko/cluster/bootstrap/DemoApp.scala
+++ b/integration-test/dns-api-mesos/src/main/scala/org/apache/pekko/cluster/bootstrap/DemoApp.scala
@@ -23,25 +23,27 @@ import pekko.stream.scaladsl.Sink
 import pekko.stream.scaladsl.Source
 import com.typesafe.config.ConfigFactory
 
-object DemoApp extends App {
+object DemoApp {
+  def main(args: Array[String]): Unit = {
 
-  implicit val system: ActorSystem = ActorSystem("simple")
+    implicit val system: ActorSystem = ActorSystem("simple")
 
-  import system.log
-  import system.dispatcher
-  val cluster = Cluster(system)
+    import system.log
+    import system.dispatcher
+    val cluster = Cluster(system)
 
-  log.info("Started [{}], cluster.selfAddress = {}", system, cluster.selfAddress)
+    log.info("Started [{}], cluster.selfAddress = {}", system, cluster.selfAddress)
 
-  PekkoManagement(system).start()
-  ClusterBootstrap(system).start()
+    PekkoManagement(system).start()
+    ClusterBootstrap(system).start()
 
-  cluster
-    .subscribe(system.actorOf(Props[ClusterWatcher]), ClusterEvent.InitialStateAsEvents, classOf[ClusterDomainEvent])
+    cluster
+      .subscribe(system.actorOf(Props[ClusterWatcher]), ClusterEvent.InitialStateAsEvents, classOf[ClusterDomainEvent])
 
-  import pekko.http.scaladsl.server.Directives._
-  Http().bindAndHandle(complete("Hello world"), "0.0.0.0", 8080)
+    import pekko.http.scaladsl.server.Directives._
+    Http().bindAndHandle(complete("Hello world"), "0.0.0.0", 8080)
 
+  }
 }
 
 class ClusterWatcher extends Actor with ActorLogging {

--- a/integration-test/kubernetes-api/src/main/scala/org/apache/pekko/cluster/bootstrap/DemoApp.scala
+++ b/integration-test/kubernetes-api/src/main/scala/org/apache/pekko/cluster/bootstrap/DemoApp.scala
@@ -25,41 +25,43 @@ import pekko.management.cluster.bootstrap.ClusterBootstrap
 import org.apache.pekko.management.scaladsl.PekkoManagement
 //#start-pekko-management
 
-object DemoApp extends App {
+object DemoApp {
+  def main(args: Array[String]): Unit = {
 
-  implicit val system: ActorSystem = ActorSystem("Appka")
+    implicit val system: ActorSystem = ActorSystem("Appka")
 
-  import system.log
-  val cluster = Cluster(system)
+    import system.log
+    val cluster = Cluster(system)
 
-  log.info(s"Started [$system], cluster.selfAddress = ${cluster.selfAddress}")
+    log.info(s"Started [$system], cluster.selfAddress = ${cluster.selfAddress}")
 
-  // #start-pekko-management
-  PekkoManagement(system).start()
-  // #start-pekko-management
-  ClusterBootstrap(system).start()
+    // #start-pekko-management
+    PekkoManagement(system).start()
+    // #start-pekko-management
+    ClusterBootstrap(system).start()
 
-  cluster.subscribe(
-    system.actorOf(Props[ClusterWatcher]()),
-    ClusterEvent.InitialStateAsEvents,
-    classOf[ClusterDomainEvent])
+    cluster.subscribe(
+      system.actorOf(Props[ClusterWatcher]()),
+      ClusterEvent.InitialStateAsEvents,
+      classOf[ClusterDomainEvent])
 
-  // add real app routes here
-  val routes =
-    path("hello") {
-      get {
-        complete(
-          HttpEntity(
-            ContentTypes.`text/html(UTF-8)`,
-            "<h1>Hello</h1>"))
+    // add real app routes here
+    val routes =
+      path("hello") {
+        get {
+          complete(
+            HttpEntity(
+              ContentTypes.`text/html(UTF-8)`,
+              "<h1>Hello</h1>"))
+        }
       }
+    Http().newServerAt("0.0.0.0", 8080).bind(routes)
+
+    Cluster(system).registerOnMemberUp {
+      log.info("Cluster member is up!")
     }
-  Http().newServerAt("0.0.0.0", 8080).bind(routes)
 
-  Cluster(system).registerOnMemberUp {
-    log.info("Cluster member is up!")
   }
-
 }
 
 class ClusterWatcher extends Actor with ActorLogging {

--- a/integration-test/local/src/main/scala/org/apache/pekko/cluster/bootstrap/Main.scala
+++ b/integration-test/local/src/main/scala/org/apache/pekko/cluster/bootstrap/Main.scala
@@ -21,16 +21,22 @@ import pekko.management.cluster.bootstrap.ClusterBootstrap
 import pekko.management.scaladsl.PekkoManagement
 
 //#main
-object Node1 extends App {
-  new Main(1)
+object Node1 {
+  def main(args: Array[String]): Unit = {
+    new Main(1)
+  }
 }
 
-object Node2 extends App {
-  new Main(2)
+object Node2 {
+  def main(args: Array[String]): Unit = {
+    new Main(2)
+  }
 }
 
-object Node3 extends App {
-  new Main(3)
+object Node3 {
+  def main(args: Array[String]): Unit = {
+    new Main(3)
+  }
 }
 
 class Main(nr: Int) {

--- a/integration-test/marathon-api-docker/src/main/scala/org/apache/pekko/cluster/bootstrap/MarathonApiDockerDemoApp.scala
+++ b/integration-test/marathon-api-docker/src/main/scala/org/apache/pekko/cluster/bootstrap/MarathonApiDockerDemoApp.scala
@@ -22,31 +22,33 @@ import pekko.http.scaladsl.server.Directives._
 import pekko.management.cluster.bootstrap.ClusterBootstrap
 import pekko.management.scaladsl.PekkoManagement
 
-object MarathonApiDockerDemoApp extends App {
-  implicit val system: ActorSystem = ActorSystem("my-system")
+object MarathonApiDockerDemoApp {
+  def main(args: Array[String]): Unit = {
+    implicit val system: ActorSystem = ActorSystem("my-system")
 
-  val cluster = Cluster(system)
+    val cluster = Cluster(system)
 
-  def isReady() = {
-    val selfNow = cluster.selfMember
+    def isReady() = {
+      val selfNow = cluster.selfMember
 
-    selfNow.status == MemberStatus.Up
+      selfNow.status == MemberStatus.Up
+    }
+
+    def isHealthy() = {
+      isReady()
+    }
+
+    val route =
+      concat(
+        path("ping")(complete("pong!")),
+        path("healthy")(complete(if (isHealthy()) StatusCodes.OK else StatusCodes.ServiceUnavailable)),
+        path("ready")(complete(if (isReady()) StatusCodes.OK else StatusCodes.ServiceUnavailable)))
+
+    PekkoManagement(system).start()
+    ClusterBootstrap(system).start()
+
+    val host: String = sys.env.get("HOST").getOrElse("127.0.0.1")
+    val port: Int = sys.env.get("PORT_HTTP").map(_.toInt).getOrElse(8080)
+    Http().newServerAt(host, port).bind(route)
   }
-
-  def isHealthy() = {
-    isReady()
-  }
-
-  val route =
-    concat(
-      path("ping")(complete("pong!")),
-      path("healthy")(complete(if (isHealthy()) StatusCodes.OK else StatusCodes.ServiceUnavailable)),
-      path("ready")(complete(if (isReady()) StatusCodes.OK else StatusCodes.ServiceUnavailable)))
-
-  PekkoManagement(system).start()
-  ClusterBootstrap(system).start()
-
-  private val host: String = sys.env.get("HOST").getOrElse("127.0.0.1")
-  private val port: Int = sys.env.get("PORT_HTTP").map(_.toInt).getOrElse(8080)
-  Http().newServerAt(host, port).bind(route)
 }

--- a/integration-test/marathon-api/src/main/scala/org/apache/pekko/cluster/bootstrap/DemoApp.scala
+++ b/integration-test/marathon-api/src/main/scala/org/apache/pekko/cluster/bootstrap/DemoApp.scala
@@ -22,32 +22,34 @@ import pekko.http.scaladsl.server.Directives._
 import pekko.management.scaladsl.PekkoManagement
 import pekko.management.cluster.bootstrap.ClusterBootstrap
 
-object DemoApp extends App {
-  implicit val system: ActorSystem = ActorSystem("my-system")
+object DemoApp {
+  def main(args: Array[String]): Unit = {
+    implicit val system: ActorSystem = ActorSystem("my-system")
 
-  val cluster = Cluster(system)
+    val cluster = Cluster(system)
 
-  def isReady() = {
-    val selfNow = cluster.selfMember
+    def isReady() = {
+      val selfNow = cluster.selfMember
 
-    selfNow.status == MemberStatus.Up
+      selfNow.status == MemberStatus.Up
+    }
+
+    def isHealthy() = {
+      isReady()
+    }
+
+    val route =
+      concat(
+        path("ping")(complete("pong!")),
+        path("healthy")(complete(if (isHealthy()) StatusCodes.OK else StatusCodes.ServiceUnavailable)),
+        path("ready")(complete(if (isReady()) StatusCodes.OK else StatusCodes.ServiceUnavailable)))
+
+    PekkoManagement(system).start()
+    ClusterBootstrap(system).start()
+
+    Http().bindAndHandle(
+      route,
+      sys.env.get("HOST").getOrElse("127.0.0.1"),
+      sys.env.get("PORT_HTTP").map(_.toInt).getOrElse(8080))
   }
-
-  def isHealthy() = {
-    isReady()
-  }
-
-  val route =
-    concat(
-      path("ping")(complete("pong!")),
-      path("healthy")(complete(if (isHealthy()) StatusCodes.OK else StatusCodes.ServiceUnavailable)),
-      path("ready")(complete(if (isReady()) StatusCodes.OK else StatusCodes.ServiceUnavailable)))
-
-  PekkoManagement(system).start()
-  ClusterBootstrap(system).start()
-
-  Http().bindAndHandle(
-    route,
-    sys.env.get("HOST").getOrElse("127.0.0.1"),
-    sys.env.get("PORT_HTTP").map(_.toInt).getOrElse(8080))
 }

--- a/integration-test/rolling-update-kubernetes/src/main/scala/org/apache/pekko/cluster/bootstrap/PodDeletionCostDemoApp.scala
+++ b/integration-test/rolling-update-kubernetes/src/main/scala/org/apache/pekko/cluster/bootstrap/PodDeletionCostDemoApp.scala
@@ -23,23 +23,25 @@ import pekko.management.scaladsl.PekkoManagement
 import pekko.rollingupdate.kubernetes.AppVersionRevision
 import pekko.rollingupdate.kubernetes.PodDeletionCost
 
-object PodDeletionCostDemoApp extends App {
+object PodDeletionCostDemoApp {
+  def main(args: Array[String]): Unit = {
 
-  implicit val system: ActorSystem = ActorSystem("pekko-rolling-update-demo")
+    implicit val system: ActorSystem = ActorSystem("pekko-rolling-update-demo")
 
-  import system.log
-  val cluster = Cluster(system)
+    import system.log
+    val cluster = Cluster(system)
 
-  log.info(s"Started [$system], cluster.selfAddress = ${cluster.selfAddress}")
+    log.info(s"Started [$system], cluster.selfAddress = ${cluster.selfAddress}")
 
-  PekkoManagement(system).start()
+    PekkoManagement(system).start()
 
-  // preferred to be called before ClusterBootstrap
-  AppVersionRevision(system).start()
+    // preferred to be called before ClusterBootstrap
+    AppVersionRevision(system).start()
 
-  ClusterBootstrap(system).start()
+    ClusterBootstrap(system).start()
 
-  PodDeletionCost(system).start()
+    PodDeletionCost(system).start()
 
-  Http().newServerAt("0.0.0.0", 8080).bind(complete("Hello world"))
+    Http().newServerAt("0.0.0.0", 8080).bind(complete("Hello world"))
+  }
 }


### PR DESCRIPTION
### Motivation
`extends App` is deprecated in Scala 3. Replace with explicit `def main(args: Array[String]): Unit` method for forward compatibility.

### Modification
Replace `object X extends App { ... }` with `object X { def main(args: Array[String]): Unit = { ... } }` in doc example and test files.

### Result
No more usage of deprecated `scala.App` trait. Code is compatible with Scala 3.

### Tests
Not run - docs only

### References
None - Scala 3 compatibility