### PR TITLE
Use StandardCharsets.UTF_8 for UTF-8 decoding

### DIFF
--- a/rolling-update-kubernetes/src/main/scala/org/apache/pekko/rollingupdate/kubernetes/KubernetesApiImpl.scala
+++ b/rolling-update-kubernetes/src/main/scala/org/apache/pekko/rollingupdate/kubernetes/KubernetesApiImpl.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.rollingupdate.kubernetes
 
 import java.util.Locale
+import java.nio.charset.StandardCharsets
 import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -455,7 +456,7 @@ PUTs must contain resourceVersions. Response:
     val file = Paths.get(path)
     if (Files.exists(file)) {
       try {
-        Some(new String(Files.readAllBytes(file), "utf-8"))
+        Some(new String(Files.readAllBytes(file), StandardCharsets.UTF_8))
       } catch {
         case NonFatal(e) =>
           log.error(e, "Error reading {} from {}", name, path)


### PR DESCRIPTION
Summary: Use StandardCharsets.UTF_8 when reading Kubernetes config files from disk. Verification: ran formatting, rolling-update-kubernetes compile, git diff --check, and residual charset literal searches.