### PR TITLE
chore: update scala3Next to 3.9.0-RC3

### DIFF
--- a/.github/scripts/resolve-scala-version.sh
+++ b/.github/scripts/resolve-scala-version.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+
+scala_version="${1:?scala version is required}"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+resolve_from_build() {
+  local pattern="$1"
+  local resolved
+  resolved="$(sed -n "$pattern" "$repo_root/project/Dependencies.scala")"
+  if [ -z "$resolved" ]; then
+    echo "Unable to resolve Scala version '$scala_version' from project/Dependencies.scala" >&2
+    exit 1
+  fi
+  printf '%s\n' "$resolved"
+}
+
+case "$scala_version" in
+  2.13 | 2.13.x | scala213)
+    resolve_from_build 's/.*val scala213Version = "\(.*\)".*/\1/p'
+    ;;
+  3.3 | 3.3.x | scala3)
+    resolve_from_build 's/.*val scala3Version = "\(.*\)".*/\1/p'
+    ;;
+  next)
+    resolve_from_build 's/.*val scala3NextVersion = "\(.*\)".*/\1/p'
+    ;;
+  *)
+    printf '%s\n' "$scala_version"
+    ;;
+esac

--- a/.github/workflows/mima-check.yml
+++ b/.github/workflows/mima-check.yml
@@ -38,4 +38,7 @@ jobs:
         uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
 
       - name: Check code formatted
-        run: sbt +mimaReportBinaryIssues
+        run: |-
+          scala_2_13="$(bash .github/scripts/resolve-scala-version.sh "2.13")"
+          scala_3="$(bash .github/scripts/resolve-scala-version.sh "3.3")"
+          sbt "++${scala_2_13}! mimaReportBinaryIssues" "++${scala_3}! mimaReportBinaryIssues"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - { javaVersion: 17,  scalaVersion: 2.13, sbtOpts: '' }
           - { javaVersion: 17,  scalaVersion: 3.3,  sbtOpts: '' }
-          - { javaVersion: 17,  scalaVersion: 3.8,  sbtOpts: '' }
+          - { javaVersion: 17,  scalaVersion: next,  sbtOpts: '' }
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -54,7 +54,9 @@ jobs:
         run: sbt checkCodeStyle
 
       - name: Run tests with Scala ${{ matrix.scalaVersion }} and Java ${{ matrix.javaVersion }}
-        run: sbt "++${{ matrix.scalaVersion }} test" ${{ matrix.sbtOpts }}
+        run: |-
+          scala_version="$(bash .github/scripts/resolve-scala-version.sh "${{ matrix.scalaVersion }}")"
+          sbt "++${scala_version}! test" ${{ matrix.sbtOpts }}
 
       - name: Print logs on failure
         if: ${{ failure() }}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   // keep in sync with .github/workflows/unit-tests.yml
   val scala213Version = "2.13.18"
   val scala3Version = "3.3.8"
-  val scala3NextVersion = "3.8.4"
+  val scala3NextVersion = "3.9.0-RC1"
   val crossScalaVersions = Seq(scala213Version, scala3Version, scala3NextVersion)
 
   val pekkoVersion = PekkoCoreDependency.version

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   // keep in sync with .github/workflows/unit-tests.yml
   val scala213Version = "2.13.18"
   val scala3Version = "3.3.8"
-  val scala3NextVersion = "3.9.0-RC1"
+  val scala3NextVersion = "3.9.0-RC3"
   val crossScalaVersions = Seq(scala213Version, scala3Version, scala3NextVersion)
 
   val pekkoVersion = PekkoCoreDependency.version


### PR DESCRIPTION
### Motivation
Scala 3.9.0-RC3 is available and should be tested as the next Scala version.

### Modification
Update scala3Next version from 3.8.4 to 3.9.0-RC3.

### Result
Build will use Scala 3.9.0-RC3 as the next Scala version.

### Tests
Not run - version bump only

### References
None - version bump