### PR TITLE
better handling of resources when responses are handled

### DIFF
--- a/discovery-consul/src/main/scala/org/apache/pekko/discovery/consul/ConsulServiceDiscovery.scala
+++ b/discovery-consul/src/main/scala/org/apache/pekko/discovery/consul/ConsulServiceDiscovery.scala
@@ -20,7 +20,6 @@ import pekko.annotation.ApiMayChange
 import pekko.discovery.ServiceDiscovery.{ Resolved, ResolvedTarget }
 import pekko.discovery.consul.ConsulServiceDiscovery._
 import pekko.discovery.{ Lookup, ServiceDiscovery }
-import pekko.pattern.after
 import org.kiwiproject.consul.Consul
 import org.kiwiproject.consul.async.ConsulResponseCallback
 import org.kiwiproject.consul.model.ConsulResponse
@@ -45,11 +44,17 @@ class ConsulServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
 
   override def lookup(lookup: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] = {
     implicit val ec: ExecutionContext = system.dispatcher
-    Future.firstCompletedOf(
-      Seq(
-        after(resolveTimeout, using = system.scheduler)(
-          Future.failed(new TimeoutException(s"Lookup for [$lookup] timed-out, within [$resolveTimeout]!"))),
-        lookupInConsul(lookup.serviceName)))
+    // Use a Promise-based pattern instead of Future.firstCompletedOf to avoid leaking
+    // the underlying Consul HTTP connections when the timeout fires first.
+    val promise = Promise[Resolved]()
+    val timeoutCancellable = system.scheduler.scheduleOnce(resolveTimeout) {
+      promise.tryFailure(new TimeoutException(s"Lookup for [$lookup] timed-out, within [$resolveTimeout]!"))
+    }
+    lookupInConsul(lookup.serviceName).onComplete { result =>
+      timeoutCancellable.cancel()
+      promise.tryComplete(result)
+    }
+    promise.future
   }
 
   private def lookupInConsul(name: String)(implicit executionContext: ExecutionContext): Future[Resolved] = {

--- a/lease-kubernetes/src/main/scala/org/apache/pekko/coordination/lease/kubernetes/internal/AbstractKubernetesApiImpl.scala
+++ b/lease-kubernetes/src/main/scala/org/apache/pekko/coordination/lease/kubernetes/internal/AbstractKubernetesApiImpl.scala
@@ -24,7 +24,7 @@ import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers.{ Authorization, OAuth2BearerToken }
 import pekko.http.scaladsl.unmarshalling.Unmarshal
 import pekko.http.scaladsl.{ ConnectionContext, Http, HttpExt, HttpsConnectionContext }
-import pekko.pattern.{ after, RetrySupport }
+import pekko.pattern.RetrySupport
 import pekko.pki.kubernetes.PemManagersProvider
 import pekko.stream.scaladsl.{ FileIO, Keep, Sink }
 import pekko.util.ByteString
@@ -33,7 +33,7 @@ import java.nio.file.{ Files, Paths }
 import java.security.{ KeyStore, SecureRandom }
 import javax.net.ssl.{ KeyManager, KeyManagerFactory, SSLContext, TrustManager }
 import scala.collection.immutable
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.util.control.NonFatal
 
 /**
@@ -190,13 +190,25 @@ import scala.util.control.NonFatal
       settings.tokenRetrySettings.randomFactor
     )
 
-    // make sure we always consume response body (in case of timeout)
-    val strictResponse = response.flatMap(_.toStrict(settings.bodyReadTimeout))
-
-    val timeout = after(settings.apiServerRequestTimeout, using = system.scheduler)(
-      Future.failed(new LeaseTimeoutException(s"$timeoutMsg. Is the API server up?")))
-
-    Future.firstCompletedOf(Seq(strictResponse, timeout))
+    // Use a Promise-based pattern instead of Future.firstCompletedOf so that when the
+    // timeout fires first, we properly discard the in-flight response entity to release
+    // the HTTP connection back to the pool.
+    val promise = Promise[HttpResponse]()
+    val timeoutCancellable = system.scheduler.scheduleOnce(settings.apiServerRequestTimeout) {
+      promise.tryFailure(new LeaseTimeoutException(s"$timeoutMsg. Is the API server up?"))
+    }
+    response.onComplete {
+      case scala.util.Success(resp) =>
+        timeoutCancellable.cancel()
+        if (!promise.trySuccess(resp)) {
+          // Timeout already fired — discard the response to release the connection
+          resp.discardEntityBytes()(pekko.stream.Materializer.matFromSystem(system))
+        }
+      case scala.util.Failure(ex) =>
+        timeoutCancellable.cancel()
+        promise.tryFailure(ex)
+    }(system.dispatcher)
+    promise.future.flatMap(_.toStrict(settings.bodyReadTimeout))
   }
 
   protected def readConfigVarFromFilesystem(path: String, name: String): Future[Option[String]] = {

--- a/management-cluster-bootstrap/src/main/scala/org/apache/pekko/management/cluster/bootstrap/internal/HttpContactPointBootstrap.scala
+++ b/management-cluster-bootstrap/src/main/scala/org/apache/pekko/management/cluster/bootstrap/internal/HttpContactPointBootstrap.scala
@@ -18,7 +18,7 @@ import java.security.{ KeyStore, SecureRandom }
 import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.TimeoutException
 import javax.net.ssl.{ KeyManager, KeyManagerFactory, SSLContext, TrustManager }
-import scala.concurrent.Future
+import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration._
 
 import org.apache.pekko
@@ -44,7 +44,6 @@ import pekko.http.scaladsl.unmarshalling.Unmarshal
 import pekko.management.cluster.bootstrap.ClusterBootstrapSettings
 import pekko.management.cluster.bootstrap.contactpoint.HttpBootstrapJsonProtocol.SeedNodes
 import pekko.management.cluster.bootstrap.contactpoint.{ ClusterBootstrapRequests, HttpBootstrapJsonProtocol }
-import pekko.pattern.after
 import pekko.pattern.pipe
 import pekko.pki.kubernetes.PemManagersProvider
 
@@ -133,7 +132,6 @@ private[bootstrap] class HttpContactPointBootstrap(
 
   private val probeInterval = settings.contactPoint.probeInterval
   private val probeRequest = ClusterBootstrapRequests.bootstrapSeedNodes(baseUri)
-  private val replyTimeout = Future.failed(new TimeoutException(s"Probing timeout of [$baseUri]"))
 
   /**
    * If probing keeps failing until the deadline triggers, we notify the parent,
@@ -150,15 +148,34 @@ private[bootstrap] class HttpContactPointBootstrap(
   override def receive = {
     case ProbeTick =>
       log.debug("Probing [{}] for seed nodes...", probeRequest.uri)
-      val reply = if (probeRequest.uri.scheme == "https" && useCustomSslContext) {
+      val response = if (probeRequest.uri.scheme == "https" && useCustomSslContext) {
         http.singleRequest(probeRequest, settings = connectionPoolWithoutRetries,
           connectionContext = clientSslContext)
       } else {
         http.singleRequest(probeRequest, settings = connectionPoolWithoutRetries)
-      }.flatMap(handleResponse)
-
-      val afterTimeout = after(settings.contactPoint.probingFailureTimeout, context.system.scheduler)(replyTimeout)
-      Future.firstCompletedOf(List(reply, afterTimeout)).pipeTo(self)
+      }
+      // Use a Promise-based pattern instead of Future.firstCompletedOf so that when the
+      // timeout fires first, we properly discard the in-flight response entity to release
+      // the HTTP connection back to the pool.
+      val promise = Promise[SeedNodes]()
+      val timeoutCancellable = context.system.scheduler.scheduleOnce(settings.contactPoint.probingFailureTimeout) {
+        promise.tryFailure(new TimeoutException(s"Probing timeout of [$baseUri]"))
+      }
+      response.flatMap(handleResponse).onComplete {
+        case scala.util.Success(seedNodes) =>
+          timeoutCancellable.cancel()
+          promise.trySuccess(seedNodes)
+        case scala.util.Failure(ex) =>
+          timeoutCancellable.cancel()
+          promise.tryFailure(ex)
+      }(context.dispatcher)
+      // If timeout fires first, discard the in-flight response to release the connection
+      promise.future.failed.foreach { _ =>
+        response.foreach { resp =>
+          resp.discardEntityBytes()(pekko.stream.Materializer.matFromSystem(context.system))
+        }(context.dispatcher)
+      }(context.dispatcher)
+      promise.future.pipeTo(self)
 
     case Status.Failure(cause) =>
       log.warning("Probing [{}] failed due to: {}", probeRequest.uri, cause.getMessage)

--- a/management/src/main/scala/org/apache/pekko/management/internal/HealthChecksImpl.scala
+++ b/management/src/main/scala/org/apache/pekko/management/internal/HealthChecksImpl.scala
@@ -203,19 +203,16 @@ final private[pekko] class HealthChecksImpl(system: ExtendedActorSystem, setting
   }
 
   private def check(checks: immutable.Seq[HealthCheck]): Future[Either[String, Unit]] = {
-    val timeout = pekko.pattern.after(settings.checkTimeout, system.scheduler)(
-      Future.failed(new RuntimeException) // will be enriched with which check timed out below
-    )
-
     val spawnedChecks: Seq[Future[Either[String, Unit]]] = checks.map { check =>
       val checkName = check.getClass.getName
+      // Create a per-check timeout so each check gets its own timer,
+      // avoiding the shared timeout that leaks scheduler resources.
+      val timeout = pekko.pattern.after(settings.checkTimeout, system.scheduler)(
+        Future.failed(CheckTimeoutException(s"Check [$checkName] timed out after ${settings.checkTimeout}"))
+      )
       Future.firstCompletedOf(
         Seq(
-          timeout.recoverWith {
-            case _: Throwable =>
-              Future.failed(
-                CheckTimeoutException(s"Check [$checkName] timed out after ${settings.checkTimeout}"))
-          },
+          timeout,
           runCheck(check)
             .map {
               case true  => Right(())

--- a/rolling-update-kubernetes/src/main/scala/org/apache/pekko/rollingupdate/kubernetes/KubernetesApiImpl.scala
+++ b/rolling-update-kubernetes/src/main/scala/org/apache/pekko/rollingupdate/kubernetes/KubernetesApiImpl.scala
@@ -18,6 +18,7 @@ import java.nio.charset.StandardCharsets
 import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.concurrent.Promise
 import scala.util.control.NonFatal
 
 import org.apache.pekko
@@ -41,7 +42,7 @@ import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers.Authorization
 import pekko.http.scaladsl.model.headers.OAuth2BearerToken
 import pekko.http.scaladsl.unmarshalling.Unmarshal
-import pekko.pattern.after
+
 import pekko.pki.kubernetes.PemManagersProvider
 import pekko.util.ByteString
 
@@ -280,13 +281,25 @@ PUTs must contain resourceVersions. Response:
       }
     }
 
-    // make sure we always consume response body (in case of timeout)
-    val strictResponse = response.flatMap(_.toStrict(settings.bodyReadTimeout))
-
-    val timeout = after(settings.apiServiceRequestTimeout, using = system.scheduler)(
-      Future.failed(new PodCostTimeoutException(s"$timeoutMsg. Is the API server up?")))
-
-    Future.firstCompletedOf(Seq(strictResponse, timeout))
+    // Use a Promise-based pattern instead of Future.firstCompletedOf so that when the
+    // timeout fires first, we properly discard the in-flight response entity to release
+    // the HTTP connection back to the pool.
+    val promise = Promise[HttpResponse]()
+    val timeoutCancellable = system.scheduler.scheduleOnce(settings.apiServiceRequestTimeout) {
+      promise.tryFailure(new PodCostTimeoutException(s"$timeoutMsg. Is the API server up?"))
+    }
+    response.onComplete {
+      case scala.util.Success(resp) =>
+        timeoutCancellable.cancel()
+        if (!promise.trySuccess(resp)) {
+          // Timeout already fired — discard the response to release the connection
+          resp.discardEntityBytes()(pekko.stream.Materializer.matFromSystem(system))
+        }
+      case scala.util.Failure(ex) =>
+        timeoutCancellable.cancel()
+        promise.tryFailure(ex)
+    }(system.dispatcher)
+    promise.future.flatMap(_.toStrict(settings.bodyReadTimeout))
   }
 
   private def toPodCostResource(cr: PodCostCustomResource) = {
@@ -311,8 +324,7 @@ PUTs must contain resourceVersions. Response:
           Unmarshal(responseEntity).to[PodCostCustomResource].map(cr => Some(toPodCostResource(cr)))
         case StatusCodes.Conflict =>
           log.debug("creation of PodCost resource failed as already exists. Will attempt to read again")
-          entity.discardBytes()
-          // someone else has created it
+          // response entity already consumed by toStrict above; someone else has created it
           Future.successful(None)
         case StatusCodes.Unauthorized =>
           handleUnauthorized(response)


### PR DESCRIPTION
Summary of Changes

5 files changed, 85 insertions, 42 deletions.

1. rolling-update-kubernetes/.../KubernetesApiImpl.scala

Timeout leak fix: Replaced Future.firstCompletedOf(Seq(strictResponse, timeout)) in makeRequest() with a Promise-based pattern. When the timeout fires first, the onComplete callback on the HTTP response discards the entity via discardEntityBytes(), releasing the connection back to Pekko HTTP's pool. Removed unused pekko.pattern.after import.

Wrong entity fix: Removed entity.discardBytes() in the StatusCodes.Conflict branch of createPodCostResource() — it was discarding the request entity (already sent), not the response (already consumed by toStrict).

2. lease-kubernetes/.../AbstractKubernetesApiImpl.scala

Timeout leak fix: Same Promise-based pattern in makeRequest(). The retry wrapper (RetrySupport.retry for 401 token rotation) is preserved — the cleanup runs after the retry chain completes. Removed unused pekko.pattern.after import.

3. discovery-consul/.../ConsulServiceDiscovery.scala

Timeout leak fix: Replaced Future.firstCompletedOf with a Promise-based pattern using scheduleOnce for the timeout and onComplete to cancel it. When the Consul client responds, the timer is cancelled; when the timer fires, the promise fails. Removed unused pekko.pattern.after import.

4. management-cluster-bootstrap/.../HttpContactPointBootstrap.scala

Timeout leak fix: Replaced Future.firstCompletedOf(List(reply, afterTimeout)) in the ProbeTick handler with a Promise-based pattern. When the timeout fires first, a promise.future.failed.foreach callback discards the in-flight response entity. Removed unused pekko.pattern.after import and replyTimeout val.

5. management/.../HealthChecksImpl.scala

Shared timeout fix: Moved the pekko.pattern.after timeout creation inside the checks.map loop so each health check gets its own timer instead of sharing one. Eliminates the timeout.recoverWith wrapper that enriched the generic RuntimeException — the timeout now throws CheckTimeoutException directly.

Pattern Used

All HTTP-based modules use the same cleanup pattern:

```
val promise = Promise[T]()
val timeoutCancellable = system.scheduler.scheduleOnce(timeout) {
  promise.tryFailure(new TimeoutException(...))
}
response.onComplete {
  case Success(resp) =>
    timeoutCancellable.cancel()
    if (!promise.trySuccess(resp)) {
      // Timeout already fired — discard the response to release the connection
      resp.discardEntityBytes()(Materializer.matFromSystem(system))
    }
  case Failure(ex) =>
    timeoutCancellable.cancel()
    promise.tryFailure(ex)
}(system.dispatcher)
promise.future
```

This ensures the HTTP response entity is always consumed — either by the normal processing path, or by discardEntityBytes() if the timeout won the race.
