### PR TITLE
improve discovery-aws-api

### DIFF
--- a/discovery-aws-api/src/main/scala/org/apache/pekko/discovery/awsapi/ec2/Ec2TagBasedServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/org/apache/pekko/discovery/awsapi/ec2/Ec2TagBasedServiceDiscovery.scala
@@ -19,7 +19,7 @@ import com.amazonaws.retry.PredefinedRetryPolicies
 import com.amazonaws.services.ec2.model.{ DescribeInstancesRequest, Filter, Reservation }
 import com.amazonaws.services.ec2.{ AmazonEC2, AmazonEC2ClientBuilder }
 import org.apache.pekko
-import pekko.actor.ExtendedActorSystem
+import pekko.actor.{ CoordinatedShutdown, ExtendedActorSystem }
 import pekko.annotation.InternalApi
 import pekko.discovery.ServiceDiscovery.{ Resolved, ResolvedTarget }
 import pekko.discovery.awsapi.ec2.Ec2TagBasedServiceDiscovery.parseFiltersString
@@ -100,7 +100,7 @@ final class Ec2TagBasedServiceDiscovery(system: ExtendedActorSystem) extends Ser
       }
   }
 
-  private val ec2Client: AmazonEC2 = {
+  private lazy val ec2Client: AmazonEC2 = {
     val clientConfiguration = clientConfigFqcn match {
       case Some(fqcn) =>
         getCustomClientConfigurationInstance(fqcn) match {
@@ -130,6 +130,13 @@ final class Ec2TagBasedServiceDiscovery(system: ExtendedActorSystem) extends Ser
     builder.build()
   }
 
+  CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseServiceUnbind, "ec2-client-close") { () =>
+    Future {
+      ec2Client.shutdown()
+      pekko.Done
+    }(ec)
+  }
+
   @tailrec
   private def getInstances(
       client: AmazonEC2,
@@ -144,9 +151,10 @@ final class Ec2TagBasedServiceDiscovery(system: ExtendedActorSystem) extends Ser
     val describeInstancesResult = client.describeInstances(describeInstancesRequest)
 
     val ips: List[String] =
-      describeInstancesResult.getReservations.asScala.toList
-        .flatMap((r: Reservation) => r.getInstances.asScala.toList)
+      describeInstancesResult.getReservations.asScala
+        .flatMap((r: Reservation) => r.getInstances.asScala)
         .map(instance => instance.getPrivateIpAddress)
+        .toList
 
     val accumulatedIps = accumulator ++ ips
 

--- a/discovery-aws-api/src/main/scala/org/apache/pekko/discovery/awsapi/ec2/Ec2TagBasedServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/org/apache/pekko/discovery/awsapi/ec2/Ec2TagBasedServiceDiscovery.scala
@@ -100,7 +100,10 @@ final class Ec2TagBasedServiceDiscovery(system: ExtendedActorSystem) extends Ser
       }
   }
 
+  @volatile private var ec2ClientUsed = false
+
   private lazy val ec2Client: AmazonEC2 = {
+    ec2ClientUsed = true
     val clientConfiguration = clientConfigFqcn match {
       case Some(fqcn) =>
         getCustomClientConfigurationInstance(fqcn) match {
@@ -131,10 +134,14 @@ final class Ec2TagBasedServiceDiscovery(system: ExtendedActorSystem) extends Ser
   }
 
   CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseServiceUnbind, "ec2-client-close") { () =>
-    Future {
-      ec2Client.shutdown()
-      pekko.Done
-    }(ec)
+    if (ec2ClientUsed) {
+      Future {
+        ec2Client.shutdown()
+        pekko.Done
+      }(ec)
+    } else {
+      Future.successful(pekko.Done)
+    }
   }
 
   @tailrec

--- a/discovery-aws-api/src/main/scala/org/apache/pekko/discovery/awsapi/ecs/EcsServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/org/apache/pekko/discovery/awsapi/ecs/EcsServiceDiscovery.scala
@@ -63,14 +63,15 @@ final class EcsServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
     builder.build()
   }
 
+  private implicit val ec: ExecutionContext =
+    system.dispatchers.lookup("pekko.actor.default-blocking-io-dispatcher")
+
   CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseServiceUnbind, "ecs-client-close") { () =>
     Future {
       ecsClient.shutdown()
       pekko.Done
-    }(system.dispatcher)
+    }(ec)
   }
-
-  private implicit val ec: ExecutionContext = system.dispatcher
 
   override def lookup(query: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] =
     Future.firstCompletedOf(

--- a/discovery-aws-api/src/main/scala/org/apache/pekko/discovery/awsapi/ecs/EcsServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/org/apache/pekko/discovery/awsapi/ecs/EcsServiceDiscovery.scala
@@ -48,7 +48,10 @@ final class EcsServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
   private val config = system.settings.config.getConfig("pekko.discovery.aws-api-ecs")
   private val cluster = config.getString("cluster")
 
+  @volatile private var ecsClientUsed = false
+
   private lazy val ecsClient = {
+    ecsClientUsed = true
     // we have our own retry/backoff mechanism, so we don't need EC2Client's in addition
     val clientConfiguration = new ClientConfiguration()
     clientConfiguration.setRetryPolicy(PredefinedRetryPolicies.NO_RETRY_POLICY)
@@ -67,10 +70,14 @@ final class EcsServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
     system.dispatchers.lookup("pekko.actor.default-blocking-io-dispatcher")
 
   CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseServiceUnbind, "ecs-client-close") { () =>
-    Future {
-      ecsClient.shutdown()
-      pekko.Done
-    }(ec)
+    if (ecsClientUsed) {
+      Future {
+        ecsClient.shutdown()
+        pekko.Done
+      }(ec)
+    } else {
+      Future.successful(pekko.Done)
+    }
   }
 
   override def lookup(query: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] =

--- a/discovery-aws-api/src/main/scala/org/apache/pekko/discovery/awsapi/ecs/EcsServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/org/apache/pekko/discovery/awsapi/ecs/EcsServiceDiscovery.scala
@@ -17,7 +17,7 @@ import java.net.{ InetAddress, NetworkInterface }
 import java.util.concurrent.TimeoutException
 
 import org.apache.pekko
-import pekko.actor.ActorSystem
+import pekko.actor.{ ActorSystem, CoordinatedShutdown }
 import pekko.discovery.{ Lookup, ServiceDiscovery }
 import pekko.discovery.ServiceDiscovery.{ Resolved, ResolvedTarget }
 import pekko.discovery.awsapi.ecs.EcsServiceDiscovery.resolveTasks
@@ -61,6 +61,13 @@ final class EcsServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
     }
 
     builder.build()
+  }
+
+  CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseServiceUnbind, "ecs-client-close") { () =>
+    Future {
+      ecsClient.shutdown()
+      pekko.Done
+    }(system.dispatcher)
   }
 
   private implicit val ec: ExecutionContext = system.dispatcher
@@ -144,7 +151,7 @@ object EcsServiceDiscovery {
   private def describeTasks(ecsClient: AmazonECS, cluster: String, taskArns: Seq[String]): Seq[Task] =
     for {
       // Each DescribeTasksRequest can contain at most 100 task ARNs.
-      group <- taskArns.grouped(100).toList
+      group <- taskArns.grouped(100).toSeq
       tasks = ecsClient.describeTasks(
         new DescribeTasksRequest().withCluster(cluster).withTasks(group.asJava))
       task <- tasks.getTasks.asScala


### PR DESCRIPTION
Blocking AWS SDK Calls on Default Dispatcher (ECS)

File: discovery-aws-api/.../EcsServiceDiscovery.scala:66

Uses system.dispatcher for blocking AWS SDK calls (listTasks, describeTasks). The EC2 module correctly uses pekko.actor.default-blocking-io-dispatcher but ECS does not. This starves actor message processing.

Fix: Change to system.dispatchers.lookup("pekko.actor.default-blocking-io-dispatcher").

L12 — Eager client initialization: Changed ec2Client from val to lazy val (line 103 in Ec2TagBasedServiceDiscovery.scala). The ECS client was already lazy val.

L13 — Unnecessary .toList materializations:
- EC2 getInstances: Removed .toList from both .asScala.toList calls (lines 147–148), letting flatMap and map operate on the lazy Buffer from .asScala, with a single .toList at the end.
- ECS describeTasks: Changed .grouped(100).toList to .grouped(100).toSeq (line 147), avoiding materializing the grouped iterator into a List of Seqs.

L14 — Clients never closed: Added CoordinatedShutdown tasks in PhaseServiceUnbind that call shutdown() on both the EC2 and ECS clients (ec2Client.shutdown(), ecsClient.shutdown()).