### PR TITLE
add graceful shutdown to management core

### DIFF
--- a/management/src/main/resources/reference.conf
+++ b/management/src/main/resources/reference.conf
@@ -70,6 +70,10 @@ pekko.management {
     # Should Management route providers only expose read only endpoints? It is up to each route provider
     # to adhere to this property
     route-providers-read-only = true
+
+    # How long to wait for in-flight requests to complete during graceful shutdown.
+    # After this deadline, remaining connections are forcibly terminated.
+    graceful-termination-timeout = 5s
   }
 
   # Health checks for startup, readiness and liveness

--- a/management/src/main/scala/org/apache/pekko/management/PekkoManagementSettings.scala
+++ b/management/src/main/scala/org/apache/pekko/management/PekkoManagementSettings.scala
@@ -17,7 +17,7 @@ import java.net.InetAddress
 import java.util.Optional
 
 import scala.collection.immutable
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.jdk.CollectionConverters._
 import scala.jdk.DurationConverters._
 import scala.jdk.OptionConverters._
@@ -81,8 +81,13 @@ final class PekkoManagementSettings(val config: Config) {
 
     val RouteProvidersReadOnly: Boolean = cc.getBoolean("route-providers-read-only")
 
-    val GracefulTerminationTimeout: FiniteDuration =
-      cc.getDuration("graceful-termination-timeout").toScala
+    val GracefulTerminationTimeout: FiniteDuration = {
+      val d = cc.getDuration("graceful-termination-timeout").toScala
+      require(
+        d > Duration.Zero,
+        s"pekko.management.http.graceful-termination-timeout must be positive (was $d)")
+      d
+    }
   }
 
   /** Java API */

--- a/management/src/main/scala/org/apache/pekko/management/PekkoManagementSettings.scala
+++ b/management/src/main/scala/org/apache/pekko/management/PekkoManagementSettings.scala
@@ -17,7 +17,9 @@ import java.net.InetAddress
 import java.util.Optional
 
 import scala.collection.immutable
+import scala.concurrent.duration.FiniteDuration
 import scala.jdk.CollectionConverters._
+import scala.jdk.DurationConverters._
 import scala.jdk.OptionConverters._
 
 import org.apache.pekko
@@ -31,7 +33,7 @@ final class PekkoManagementSettings(val config: Config) {
   object Http {
     private val cc = managementConfig.getConfig("http")
 
-    val Hostname: String = {
+    lazy val Hostname: String = {
       val hostname = cc.getString("hostname")
       if (hostname == "<hostname>") InetAddress.getLocalHost.getHostAddress
       else if (hostname.trim() == "") InetAddress.getLocalHost.getHostAddress
@@ -78,6 +80,9 @@ final class PekkoManagementSettings(val config: Config) {
     }
 
     val RouteProvidersReadOnly: Boolean = cc.getBoolean("route-providers-read-only")
+
+    val GracefulTerminationTimeout: FiniteDuration =
+      cc.getDuration("graceful-termination-timeout").toScala
   }
 
   /** Java API */

--- a/management/src/main/scala/org/apache/pekko/management/scaladsl/PekkoManagement.scala
+++ b/management/src/main/scala/org/apache/pekko/management/scaladsl/PekkoManagement.scala
@@ -238,7 +238,9 @@ final class PekkoManagement(implicit private[pekko] val system: ExtendedActorSys
     if (binding == null) {
       Future.successful(Done)
     } else if (bindingFuture.compareAndSet(binding, null)) {
-      binding._2.flatMap(_.unbind()).map((_: Any) => Done)
+      binding._2
+        .flatMap(_.terminate(settings.Http.GracefulTerminationTimeout))
+        .map((_: Any) => Done)
     } else stop() // retry, CAS was not successful, someone else completed the stop()
   }
 


### PR DESCRIPTION
│ L17 — Blocking DNS on   │ Hostname changed from val to lazy val so InetAddress.getLocalHost is deferred  │ PekkoManagementSettings.scala:33                  │
│ startup                 │ until first access                                                             │                                                   │

│ M22 — No graceful       │ stop() calls terminate(timeout) instead of unbind(), allowing in-flight        │ PekkoManagement.scala:241-242                     │
│ shutdown                │ requests to complete                                                           │                                                   │

│ M22 (config)            │ New graceful-termination-timeout = 5s setting                                  │ reference.conf:74,                                │
│                         │                                                                                │ PekkoManagementSettings.scala:82-83