### PR TITLE
apply jitter to interval to avoid thundering herd issues

### DIFF
--- a/management-cluster-bootstrap/src/main/scala/org/apache/pekko/management/cluster/bootstrap/internal/BootstrapCoordinator.scala
+++ b/management-cluster-bootstrap/src/main/scala/org/apache/pekko/management/cluster/bootstrap/internal/BootstrapCoordinator.scala
@@ -183,11 +183,19 @@ private[pekko] class BootstrapCoordinator(
     }
   }
   def startSingleDiscoveryTimer(): Unit = {
-    val interval = backedOffInterval(
+    val baseInterval = backedOffInterval(
       discoveryFailedBackoffCounter,
       settings.contactPointDiscovery.interval,
       settings.contactPointDiscovery.exponentialBackoffMax,
       settings.contactPointDiscovery.exponentialBackoffRandomFactor)
+    // Apply symmetric jitter to the base interval to prevent thundering herd
+    // even during normal (non-backoff) operation.
+    val jitterFactor = settings.contactPointDiscovery.exponentialBackoffRandomFactor
+    val jitter = 1.0 + (ThreadLocalRandom.current().nextDouble() * 2 - 1) * jitterFactor
+    val interval = baseInterval * jitter match {
+      case f: FiniteDuration if f > Duration.Zero => f
+      case _                                      => baseInterval
+    }
     timers.startSingleTimer(DiscoverTimerKey, DiscoverTick, interval)
   }
 


### PR DESCRIPTION
❯ │ M5  │ Bootstrap      │ Thundering herd risk — jitter only on failure, not normal interval   │

The problem: startSingleDiscoveryTimer calls backedOffInterval which applies jitter, but the jitter formula interval * (1.0 + random) only scales above the base interval. More importantly, the comment in the code and config only mention jitter in the context of backoff — during normal operation (counter=0), the interval is base * (1.0..1.2), which is always ≥ base. Nodes that start at the same time will always discover at approximately the same cadence.

The fix: always apply symmetric jitter to the base interval, regardless of backoff state.