### PR TITLE
No Request-Level Timeout on K8s API singleRequest

### DIFF
--- a/discovery-kubernetes-api/src/main/scala/org/apache/pekko/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/org/apache/pekko/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.discovery.kubernetes
 
 import java.net.InetAddress
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeoutException
 import java.nio.file.{ Files, Paths }
 import java.security.{ KeyStore, SecureRandom }
 import javax.net.ssl.{ KeyManager, KeyManagerFactory, SSLContext, TrustManager }
@@ -23,6 +24,7 @@ import scala.collection.immutable
 import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.concurrent.Promise
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 import scala.util.control.{ NoStackTrace, NonFatal }
@@ -156,7 +158,24 @@ class KubernetesApiServiceDiscovery(settings: Settings)(
         )
       }
 
-      response <- http.singleRequest(request, setup.clientHttpsConnectionContext).map(decodeResponse)
+      response <- {
+        val rawResponse = http.singleRequest(request, setup.clientHttpsConnectionContext)
+        val promise = Promise[HttpResponse]()
+        val timeoutCancellable = system.scheduler.scheduleOnce(resolveTimeout) {
+          promise.tryFailure(new TimeoutException(s"Kubernetes API request timed out after $resolveTimeout"))
+        }
+        rawResponse.onComplete {
+          case scala.util.Success(resp) =>
+            timeoutCancellable.cancel()
+            if (!promise.trySuccess(resp)) {
+              resp.discardEntityBytes()
+            }
+          case scala.util.Failure(ex) =>
+            timeoutCancellable.cancel()
+            promise.tryFailure(ex)
+        }(system.dispatcher)
+        promise.future.map(decodeResponse)
+      }
 
       entity <- response.entity.toStrict(resolveTimeout)
 


### PR DESCRIPTION
H11. No Request-Level Timeout on K8s API singleRequest

File: discovery-kubernetes-api/.../KubernetesApiServiceDiscovery.scala:159

http.singleRequest() has no request timeout. If the K8s API server is unreachable, the call can hang indefinitely.
