### PR TITLE
change tlsVersion to minTlsVersion but keep the tls-version config name

### DIFF
--- a/discovery-kubernetes-api/src/main/resources/reference.conf
+++ b/discovery-kubernetes-api/src/main/resources/reference.conf
@@ -17,7 +17,7 @@ pekko.discovery {
     api-service-host-env-name = "KUBERNETES_SERVICE_HOST"
     api-service-port-env-name = "KUBERNETES_SERVICE_PORT"
 
-    # the TLS version to use when connecting to the API server
+    # the minimum TLS version to use when connecting to the API server
     tls-version = "TLSv1.2"
 
     # Namespace discovery path

--- a/discovery-kubernetes-api/src/main/scala/org/apache/pekko/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/org/apache/pekko/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
@@ -231,8 +231,9 @@ class KubernetesApiServiceDiscovery(settings: Settings)(
    * This uses blocking IO, and so should only be used at startup from blocking dispatcher.
    */
   private def clientHttpsConnectionContext(): HttpsConnectionContext = {
-    val sslContext = PemManagersProvider.createSslContext(settings.apiCaPath, settings.tlsVersion)
-    ConnectionContext.httpsClient(sslContext)
+    val sslContext = PemManagersProvider.createSslContext(settings.apiCaPath)
+    ConnectionContext.httpsClient((host, port) =>
+      PemManagersProvider.configureClientEngine(sslContext.createSSLEngine(host, port), settings.minTlsVersion))
   }
 
   /**

--- a/discovery-kubernetes-api/src/main/scala/org/apache/pekko/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/org/apache/pekko/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
@@ -231,7 +231,7 @@ class KubernetesApiServiceDiscovery(settings: Settings)(
    * This uses blocking IO, and so should only be used at startup from blocking dispatcher.
    */
   private def clientHttpsConnectionContext(): HttpsConnectionContext = {
-    val sslContext = PemManagersProvider.createSslContext(settings.apiCaPath, settings.tlsVersion)
+    val sslContext = PemManagersProvider.createSslContext(settings.apiCaPath, settings.minTlsVersion)
     ConnectionContext.httpsClient(sslContext)
   }
 

--- a/discovery-kubernetes-api/src/main/scala/org/apache/pekko/discovery/kubernetes/Settings.scala
+++ b/discovery-kubernetes-api/src/main/scala/org/apache/pekko/discovery/kubernetes/Settings.scala
@@ -49,7 +49,7 @@ final class Settings(kubernetesApi: Config) extends Extension {
   val apiServicePortEnvName: String =
     kubernetesApi.getString("api-service-port-env-name")
 
-  val tlsVersion: String =
+  val minTlsVersion: String =
     kubernetesApi.getString("tls-version")
 
   val podNamespacePath: String =
@@ -76,7 +76,8 @@ final class Settings(kubernetesApi: Config) extends Extension {
 
   override def toString =
     s"Settings($apiCaPath, $apiTokenPath, $apiServiceHostEnvName, $apiServicePortEnvName, " +
-    s"$podNamespacePath, $podNamespace, $podDomain, httpRequestAcceptEncoding=$httpRequestAcceptEncoding)"
+    s"$podNamespacePath, $podNamespace, $podDomain, minTlsVersion=$minTlsVersion, " +
+    s"httpRequestAcceptEncoding=$httpRequestAcceptEncoding)"
 }
 
 object Settings extends ExtensionId[Settings] with ExtensionIdProvider {

--- a/discovery-kubernetes-api/src/test/scala/org/apache/pekko/discovery/kubernetes/SettingsSpec.scala
+++ b/discovery-kubernetes-api/src/test/scala/org/apache/pekko/discovery/kubernetes/SettingsSpec.scala
@@ -26,11 +26,11 @@ import org.scalatest.wordspec.AnyWordSpec
 class SettingsSpec extends AnyWordSpec with Matchers {
 
   "Settings" should {
-    "default tls-version to v1.2" in {
+    "default min-tls-version to v1.2" in {
       val system = ActorSystem("test")
       try {
         val settings = Settings(system)
-        settings.tlsVersion shouldBe "TLSv1.2"
+        settings.minTlsVersion shouldBe "TLSv1.2"
       } finally {
         system.terminate()
       }
@@ -44,7 +44,7 @@ class SettingsSpec extends AnyWordSpec with Matchers {
       val system = ActorSystem("test", config)
       try {
         val settings = Settings(system)
-        settings.tlsVersion shouldBe "TLSv1.3"
+        settings.minTlsVersion shouldBe "TLSv1.3"
       } finally {
         system.terminate()
       }

--- a/lease-kubernetes/src/main/resources/reference.conf
+++ b/lease-kubernetes/src/main/resources/reference.conf
@@ -45,7 +45,7 @@ pekko.coordination.lease.kubernetes {
     # set to false for plain text with no auth
     secure-api-server = true
 
-    # the TLS version to use when connecting to the API server
+    # the minimum TLS version to use when connecting to the API server
     tls-version = "TLSv1.2"
 
     # The amount of time to wait for a lease to be acquired or released. This includes all requests to the API

--- a/lease-kubernetes/src/main/scala/org/apache/pekko/coordination/lease/kubernetes/KubernetesSettings.scala
+++ b/lease-kubernetes/src/main/scala/org/apache/pekko/coordination/lease/kubernetes/KubernetesSettings.scala
@@ -71,7 +71,7 @@ private[pekko] object KubernetesSettings {
       config.getString("namespace-path"),
       apiServerRequestTimeout,
       secure = config.getBoolean("secure-api-server"),
-      tlsVersion = config.getString("tls-version"),
+      minTlsVersion = config.getString("tls-version"),
       bodyReadTimeout = apiServerRequestTimeout / 2,
       tokenRetrySettings = tokenRetrySettings,
       leaseLabelMaxLength = config.getInt("lease-name-max-length"),
@@ -102,7 +102,7 @@ private[pekko] class KubernetesSettings(
     val namespacePath: String,
     val apiServerRequestTimeout: FiniteDuration,
     val secure: Boolean = true,
-    val tlsVersion: String = "TLSv1.2",
+    val minTlsVersion: String = "TLSv1.2",
     val bodyReadTimeout: FiniteDuration = 1.second,
     val tokenRetrySettings: TokenRetrySettings = new TokenRetrySettings(
       5,

--- a/lease-kubernetes/src/main/scala/org/apache/pekko/coordination/lease/kubernetes/internal/AbstractKubernetesApiImpl.scala
+++ b/lease-kubernetes/src/main/scala/org/apache/pekko/coordination/lease/kubernetes/internal/AbstractKubernetesApiImpl.scala
@@ -51,9 +51,11 @@ import scala.util.control.NonFatal
   private val http: HttpExt = Http()(system)
 
   private lazy val sslContext: SSLContext =
-    PemManagersProvider.createSslContext(settings.apiCaPath, settings.tlsVersion)
+    PemManagersProvider.createSslContext(settings.apiCaPath)
 
-  private lazy val clientSslContext: HttpsConnectionContext = ConnectionContext.httpsClient(sslContext)
+  private lazy val clientSslContext: HttpsConnectionContext =
+    ConnectionContext.httpsClient((host, port) =>
+      PemManagersProvider.configureClientEngine(sslContext.createSSLEngine(host, port), settings.minTlsVersion))
 
   protected val namespace: Future[String] = {
     settings.namespace match {

--- a/lease-kubernetes/src/main/scala/org/apache/pekko/coordination/lease/kubernetes/internal/AbstractKubernetesApiImpl.scala
+++ b/lease-kubernetes/src/main/scala/org/apache/pekko/coordination/lease/kubernetes/internal/AbstractKubernetesApiImpl.scala
@@ -51,7 +51,7 @@ import scala.util.control.NonFatal
   private val http: HttpExt = Http()(system)
 
   private lazy val sslContext: SSLContext =
-    PemManagersProvider.createSslContext(settings.apiCaPath, settings.tlsVersion)
+    PemManagersProvider.createSslContext(settings.apiCaPath, settings.minTlsVersion)
 
   private lazy val clientSslContext: HttpsConnectionContext = ConnectionContext.httpsClient(sslContext)
 

--- a/lease-kubernetes/src/test/scala/org/apache/pekko/coordination/lease/kubernetes/KubernetesSettingsSpec.scala
+++ b/lease-kubernetes/src/test/scala/org/apache/pekko/coordination/lease/kubernetes/KubernetesSettingsSpec.scala
@@ -41,11 +41,11 @@ class KubernetesSettingsSpec extends AnyWordSpec with Matchers {
            api-server-request-timeout=4s
         """.stripMargin).apiServerRequestTimeout shouldEqual 4.seconds
     }
-    "default tls-version to v1.2" in {
-      conf("").tlsVersion shouldEqual "TLSv1.2"
+    "default min-tls-version to v1.2" in {
+      conf("").minTlsVersion shouldEqual "TLSv1.2"
     }
     "support tls-version override" in {
-      conf("tls-version=TLSv1.3").tlsVersion shouldEqual "TLSv1.3"
+      conf("tls-version=TLSv1.3").minTlsVersion shouldEqual "TLSv1.3"
     }
     "default lease-name-max-length to 63" in {
       conf("").leaseLabelMaxLength shouldEqual 63

--- a/management-cluster-bootstrap/src/main/resources/reference.conf
+++ b/management-cluster-bootstrap/src/main/resources/reference.conf
@@ -140,7 +140,7 @@ pekko.management {
         # if this is left empty, the default Java Runtime trust store will be used
         # pekko-management-cluster-bootstrap 1.2.0 did not default to the Java Runtime trust store
         ca-path = ""
-        # the TLS version to use when connecting to contact points
+        # the minimum TLS version to use when connecting to contact points
         tls-version = "TLSv1.2"
       }
     }

--- a/management-cluster-bootstrap/src/main/scala/org/apache/pekko/management/cluster/bootstrap/ClusterBootstrapSettings.scala
+++ b/management-cluster-bootstrap/src/main/scala/org/apache/pekko/management/cluster/bootstrap/ClusterBootstrapSettings.scala
@@ -139,7 +139,7 @@ final class ClusterBootstrapSettings(config: Config, log: LoggingAdapter) {
       private val httpClientConfig = contactPointConfig.getConfig("http-client")
 
       val caPath: String = httpClientConfig.getString("ca-path")
-      val tlsVersion: String = httpClientConfig.getString("tls-version")
+      val minTlsVersion: String = httpClientConfig.getString("tls-version")
     }
 
     val fallbackPort: Int =

--- a/management-cluster-bootstrap/src/main/scala/org/apache/pekko/management/cluster/bootstrap/internal/HttpContactPointBootstrap.scala
+++ b/management-cluster-bootstrap/src/main/scala/org/apache/pekko/management/cluster/bootstrap/internal/HttpContactPointBootstrap.scala
@@ -14,10 +14,9 @@
 package org.apache.pekko.management.cluster.bootstrap.internal
 
 import java.time.LocalDateTime
-import java.security.{ KeyStore, SecureRandom }
 import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.TimeoutException
-import javax.net.ssl.{ KeyManager, KeyManagerFactory, SSLContext, TrustManager }
+import javax.net.ssl.SSLContext
 import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration._
 
@@ -67,24 +66,16 @@ private[bootstrap] object HttpContactPointBootstrap {
   private val DefaultTlsVersion = "TLSv1.2" // keep in sync with default in reference.conf
 
   def generateSSLContext(settings: ClusterBootstrapSettings): SSLContext = {
-    val factory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
-    val keyStore = KeyStore.getInstance("PKCS12")
-    keyStore.load(null)
-    factory.init(keyStore, Array.empty)
-    val km: Array[KeyManager] = factory.getKeyManagers
     val caPath = settings.contactPoint.httpClient.caPath.trim
-    val tm: Array[TrustManager] = if (caPath.isEmpty) {
-      // null means use the default JVM trust store, which is what we want if no CA path is configured
-      None.orNull
-    } else {
-      val certificates = PemManagersProvider.loadCertificates(caPath)
-      PemManagersProvider.buildTrustManagers(certificates)
-    }
-    val tlsVersion = settings.contactPoint.httpClient.tlsVersion.trim
-    val random: SecureRandom = new SecureRandom
-    val sslContext = SSLContext.getInstance(tlsVersion)
-    sslContext.init(km, tm, random)
-    sslContext
+    // an empty ca-path means use the default JVM trust store
+    PemManagersProvider.createSslContext(if (caPath.nonEmpty) Some(caPath) else None)
+  }
+
+  def generateClientConnectionContext(settings: ClusterBootstrapSettings): HttpsConnectionContext = {
+    val sslContext = generateSSLContext(settings)
+    val minTlsVersion = settings.contactPoint.httpClient.minTlsVersion.trim
+    ConnectionContext.httpsClient((host, port) =>
+      PemManagersProvider.configureClientEngine(sslContext.createSSLEngine(host, port), minTlsVersion))
   }
 }
 
@@ -120,10 +111,10 @@ private[bootstrap] class HttpContactPointBootstrap(
 
   private val useCustomSslContext: Boolean =
     settings.contactPoint.httpClient.caPath.trim.nonEmpty ||
-    settings.contactPoint.httpClient.tlsVersion != DefaultTlsVersion
+    settings.contactPoint.httpClient.minTlsVersion != DefaultTlsVersion
 
   private lazy val clientSslContext: HttpsConnectionContext =
-    ConnectionContext.httpsClient(generateSSLContext(settings))
+    generateClientConnectionContext(settings)
 
   private val http = Http()
 

--- a/management-cluster-bootstrap/src/main/scala/org/apache/pekko/management/cluster/bootstrap/internal/HttpContactPointBootstrap.scala
+++ b/management-cluster-bootstrap/src/main/scala/org/apache/pekko/management/cluster/bootstrap/internal/HttpContactPointBootstrap.scala
@@ -14,10 +14,9 @@
 package org.apache.pekko.management.cluster.bootstrap.internal
 
 import java.time.LocalDateTime
-import java.security.{ KeyStore, SecureRandom }
 import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.TimeoutException
-import javax.net.ssl.{ KeyManager, KeyManagerFactory, SSLContext, TrustManager }
+import javax.net.ssl.SSLContext
 import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration._
 
@@ -67,24 +66,10 @@ private[bootstrap] object HttpContactPointBootstrap {
   private val DefaultTlsVersion = "TLSv1.2" // keep in sync with default in reference.conf
 
   def generateSSLContext(settings: ClusterBootstrapSettings): SSLContext = {
-    val factory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
-    val keyStore = KeyStore.getInstance("PKCS12")
-    keyStore.load(null)
-    factory.init(keyStore, Array.empty)
-    val km: Array[KeyManager] = factory.getKeyManagers
     val caPath = settings.contactPoint.httpClient.caPath.trim
-    val tm: Array[TrustManager] = if (caPath.isEmpty) {
-      // null means use the default JVM trust store, which is what we want if no CA path is configured
-      None.orNull
-    } else {
-      val certificates = PemManagersProvider.loadCertificates(caPath)
-      PemManagersProvider.buildTrustManagers(certificates)
-    }
-    val tlsVersion = settings.contactPoint.httpClient.tlsVersion.trim
-    val random: SecureRandom = new SecureRandom
-    val sslContext = SSLContext.getInstance(tlsVersion)
-    sslContext.init(km, tm, random)
-    sslContext
+    val caCertPath = if (caPath.nonEmpty) Some(caPath) else None
+    val minTlsVersion = settings.contactPoint.httpClient.minTlsVersion.trim
+    PemManagersProvider.createSslContext(caCertPath, minTlsVersion)
   }
 }
 
@@ -120,7 +105,7 @@ private[bootstrap] class HttpContactPointBootstrap(
 
   private val useCustomSslContext: Boolean =
     settings.contactPoint.httpClient.caPath.trim.nonEmpty ||
-    settings.contactPoint.httpClient.tlsVersion != DefaultTlsVersion
+    settings.contactPoint.httpClient.minTlsVersion != DefaultTlsVersion
 
   private lazy val clientSslContext: HttpsConnectionContext =
     ConnectionContext.httpsClient(generateSSLContext(settings))

--- a/management-cluster-bootstrap/src/test/scala/org/apache/pekko/management/cluster/bootstrap/internal/HttpContactPointBootstrapSpec.scala
+++ b/management-cluster-bootstrap/src/test/scala/org/apache/pekko/management/cluster/bootstrap/internal/HttpContactPointBootstrapSpec.scala
@@ -19,6 +19,7 @@ import org.apache.pekko
 import pekko.actor.{ ActorPath, ActorSystem }
 import pekko.event.Logging
 import pekko.management.cluster.bootstrap.ClusterBootstrapSettings
+import pekko.pki.kubernetes.PemManagersProvider
 import pekko.http.scaladsl.model.Uri.Host
 import com.typesafe.config.ConfigFactory
 import org.scalatest.matchers.should.Matchers
@@ -73,7 +74,7 @@ class HttpContactPointBootstrapSpec extends AnyWordSpec with Matchers {
         sys.terminate()
       }
     }
-    "fail to generate SSLContext with bad tls-version" in {
+    "fail with bad tls-version when a connection engine is created" in {
       val sys = ActorSystem("HttpContactPointBootstrapSpec")
       val log = Logging(sys, classOf[HttpContactPointBootstrapSpec])
       try {
@@ -83,10 +84,37 @@ class HttpContactPointBootstrapSpec extends AnyWordSpec with Matchers {
             tls-version = "BAD_VERSION"
           }""").withFallback(sys.settings.config)
         val settings = new ClusterBootstrapSettings(cfg, log)
-        val noSuchAlgorithmException = intercept[java.security.NoSuchAlgorithmException] {
-          HttpContactPointBootstrap.generateSSLContext(settings)
+        // the context builds fine; the version is validated per connection engine
+        HttpContactPointBootstrap.generateClientConnectionContext(settings) should not be null
+        val sslContext = HttpContactPointBootstrap.generateSSLContext(settings)
+        val illegalArgumentException = intercept[IllegalArgumentException] {
+          PemManagersProvider.configureClientEngine(
+            sslContext.createSSLEngine("example.com", 443),
+            settings.contactPoint.httpClient.minTlsVersion.trim)
         }
-        noSuchAlgorithmException.getMessage.contains("BAD_VERSION") should be(true)
+        illegalArgumentException.getMessage.contains("BAD_VERSION") should be(true)
+      } finally {
+        sys.terminate()
+      }
+    }
+
+    "restrict the enabled protocols to the configured minimum" in {
+      val sys = ActorSystem("HttpContactPointBootstrapSpec")
+      val log = Logging(sys, classOf[HttpContactPointBootstrapSpec])
+      try {
+        val cfg = ConfigFactory.parseString(s"""
+          pekko.management.cluster.bootstrap.contact-point.http-client {
+            ca-path = "${userDir}/src/test/files/ca.crt"
+            tls-version = "TLSv1.3"
+          }""").withFallback(sys.settings.config)
+        val settings = new ClusterBootstrapSettings(cfg, log)
+        HttpContactPointBootstrap.generateClientConnectionContext(settings) should not be null
+        val sslContext = HttpContactPointBootstrap.generateSSLContext(settings)
+        val engine = PemManagersProvider.configureClientEngine(
+          sslContext.createSSLEngine("example.com", 443),
+          settings.contactPoint.httpClient.minTlsVersion.trim)
+        engine.getEnabledProtocols.toSeq shouldEqual Seq("TLSv1.3")
+        engine.getSSLParameters.getEndpointIdentificationAlgorithm shouldEqual "https"
       } finally {
         sys.terminate()
       }

--- a/management-cluster-bootstrap/src/test/scala/org/apache/pekko/management/cluster/bootstrap/internal/HttpContactPointBootstrapSpec.scala
+++ b/management-cluster-bootstrap/src/test/scala/org/apache/pekko/management/cluster/bootstrap/internal/HttpContactPointBootstrapSpec.scala
@@ -83,10 +83,10 @@ class HttpContactPointBootstrapSpec extends AnyWordSpec with Matchers {
             tls-version = "BAD_VERSION"
           }""").withFallback(sys.settings.config)
         val settings = new ClusterBootstrapSettings(cfg, log)
-        val noSuchAlgorithmException = intercept[java.security.NoSuchAlgorithmException] {
+        val illegalArgumentException = intercept[IllegalArgumentException] {
           HttpContactPointBootstrap.generateSSLContext(settings)
         }
-        noSuchAlgorithmException.getMessage.contains("BAD_VERSION") should be(true)
+        illegalArgumentException.getMessage.contains("BAD_VERSION") should be(true)
       } finally {
         sys.terminate()
       }

--- a/management-pki/src/main/scala/org/apache/pekko/pki/kubernetes/PemManagersProvider.scala
+++ b/management-pki/src/main/scala/org/apache/pekko/pki/kubernetes/PemManagersProvider.scala
@@ -27,7 +27,7 @@ import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.pki.pem.{ DERPrivateKeyLoader, PEMDecoder }
 
-import javax.net.ssl.{ KeyManagerFactory, SSLContext, TrustManager, TrustManagerFactory }
+import javax.net.ssl.{ KeyManagerFactory, SSLContext, SSLEngine, TrustManager, TrustManagerFactory }
 
 /**
  * INTERNAL API
@@ -71,17 +71,84 @@ private[pekko] object PemManagersProvider {
   /**
    * INTERNAL API
    *
-   * Creates an SSLContext that trusts the given CA certificate file, with no client key material.
+   * TLS protocol versions in ascending order of preference. Anything not listed here
+   * (for example SSLv3 or the "SSLv2Hello" pseudo-protocol) is never selected by
+   * [[protocolsAtOrAbove]].
    */
-  @InternalApi def createSslContext(caCertPath: String, tlsVersion: String): SSLContext = {
-    val certificates = loadCertificates(caCertPath)
+  private val TlsVersionOrder = Map("TLSv1" -> 1, "TLSv1.1" -> 2, "TLSv1.2" -> 3, "TLSv1.3" -> 4)
+
+  /**
+   * INTERNAL API
+   *
+   * The subset of `supportedProtocols` that is at or above `minTlsVersion`.
+   *
+   * A minimum version can only be enforced on an `SSLSocket` or `SSLEngine`; an `SSLContext`
+   * has no mutable protocol list, so callers must apply the result via
+   * [[configureClientEngine]] or `SSLSocket.setEnabledProtocols`.
+   *
+   * @throws IllegalArgumentException if `minTlsVersion` is not a known TLS version, or if no
+   *                                  supported protocol satisfies it.
+   */
+  @InternalApi def protocolsAtOrAbove(minTlsVersion: String, supportedProtocols: Array[String]): Array[String] = {
+    val minOrder = TlsVersionOrder.getOrElse(
+      minTlsVersion,
+      throw new IllegalArgumentException(
+        s"Unknown TLS version [$minTlsVersion]. Supported values: " +
+        TlsVersionOrder.keys.toSeq.sorted.mkString(", ")))
+    val filtered = supportedProtocols.filter(protocol => TlsVersionOrder.get(protocol).exists(_ >= minOrder))
+    if (filtered.isEmpty)
+      throw new IllegalArgumentException(
+        s"No TLS protocol at or above [$minTlsVersion] is supported. Supported protocols: " +
+        supportedProtocols.mkString(", "))
+    filtered
+  }
+
+  /**
+   * INTERNAL API
+   *
+   * Configures `engine` as a client engine that only negotiates TLS versions at or above
+   * `minTlsVersion`, keeping the "https" endpoint identification algorithm that
+   * `ConnectionContext.httpsClient(sslContext)` would otherwise apply, so hostname
+   * verification is not lost.
+   */
+  @InternalApi def configureClientEngine(engine: SSLEngine, minTlsVersion: String): SSLEngine = {
+    engine.setUseClientMode(true)
+    engine.setEnabledProtocols(protocolsAtOrAbove(minTlsVersion, engine.getSupportedProtocols))
+    val params = engine.getSSLParameters
+    params.setEndpointIdentificationAlgorithm("https")
+    engine.setSSLParameters(params)
+    engine
+  }
+
+  /**
+   * INTERNAL API
+   *
+   * Creates an SSLContext that trusts the given CA certificate file, with no client key material.
+   *
+   * The returned context supports every TLS version the JVM enables by default; a minimum
+   * version cannot be pinned on an `SSLContext`, so restrict the connection itself with
+   * [[configureClientEngine]].
+   */
+  @InternalApi def createSslContext(caCertPath: String): SSLContext =
+    createSslContext(Some(caCertPath))
+
+  /**
+   * INTERNAL API
+   *
+   * Creates an SSLContext with no client key material. If `caCertPath` is `Some(path)` the CA
+   * certificates in that file are trusted, otherwise the default JVM trust store is used.
+   */
+  @InternalApi def createSslContext(caCertPath: Option[String]): SSLContext = {
+    val tm = caCertPath match {
+      case Some(path) => buildTrustManagers(loadCertificates(path))
+      case None       => null // null means use the default JVM trust store
+    }
     val factory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
     val ks = KeyStore.getInstance("PKCS12")
     ks.load(null)
     factory.init(ks, Array.empty)
     val km = factory.getKeyManagers
-    val tm = buildTrustManagers(certificates)
-    val sslContext = SSLContext.getInstance(tlsVersion)
+    val sslContext = SSLContext.getInstance("TLS")
     sslContext.init(km, tm, new SecureRandom)
     sslContext
   }

--- a/management-pki/src/main/scala/org/apache/pekko/pki/kubernetes/PemManagersProvider.scala
+++ b/management-pki/src/main/scala/org/apache/pekko/pki/kubernetes/PemManagersProvider.scala
@@ -68,21 +68,49 @@ private[pekko] object PemManagersProvider {
     certFactory.generateCertificates(Files.newInputStream(new File(filename).toPath)).asScala
   }
 
+  private val TlsVersionOrder = Map("TLSv1" -> 1, "TLSv1.1" -> 2, "TLSv1.2" -> 3, "TLSv1.3" -> 4)
+
   /**
    * INTERNAL API
    *
    * Creates an SSLContext that trusts the given CA certificate file, with no client key material.
+   * Only TLS protocol versions at or above the given `minTlsVersion` are enabled.
    */
-  @InternalApi def createSslContext(caCertPath: String, tlsVersion: String): SSLContext = {
-    val certificates = loadCertificates(caCertPath)
+  @InternalApi def createSslContext(caCertPath: String, minTlsVersion: String): SSLContext = {
+    createSslContext(Some(caCertPath), minTlsVersion)
+  }
+
+  /**
+   * INTERNAL API
+   *
+   * Creates an SSLContext with no client key material.
+   * If `caCertPath` is `Some(path)`, trusts the CA certificates in that file.
+   * If `caCertPath` is `None`, uses the default JVM trust store.
+   * Only TLS protocol versions at or above the given `minTlsVersion` are enabled.
+   */
+  @InternalApi def createSslContext(caCertPath: Option[String], minTlsVersion: String): SSLContext = {
+    val tm = caCertPath match {
+      case Some(path) => buildTrustManagers(loadCertificates(path))
+      case None       => null // use default JVM trust store
+    }
     val factory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
     val ks = KeyStore.getInstance("PKCS12")
     ks.load(null)
     factory.init(ks, Array.empty)
     val km = factory.getKeyManagers
-    val tm = buildTrustManagers(certificates)
-    val sslContext = SSLContext.getInstance(tlsVersion)
+    val sslContext = SSLContext.getInstance("TLS")
     sslContext.init(km, tm, new SecureRandom)
+    val minOrder = TlsVersionOrder.getOrElse(minTlsVersion,
+      throw new IllegalArgumentException(s"Unknown TLS version: $minTlsVersion. " +
+        s"Supported values: ${TlsVersionOrder.keys.mkString(", ")}"))
+    val defaultParams = sslContext.getDefaultSSLParameters
+    val filteredProtocols = defaultParams.getProtocols.filter { protocol =>
+      TlsVersionOrder.get(protocol).exists(_ >= minOrder)
+    }
+    require(filteredProtocols.nonEmpty,
+      s"No supported TLS protocols at or above $minTlsVersion. " +
+      s"Supported protocols: ${defaultParams.getProtocols.mkString(", ")}")
+    defaultParams.setProtocols(filteredProtocols)
     sslContext
   }
 

--- a/management-pki/src/test/scala/org/apache/pekko/pki/kubernetes/PemManagersProviderSpec.scala
+++ b/management-pki/src/test/scala/org/apache/pekko/pki/kubernetes/PemManagersProviderSpec.scala
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.pki.kubernetes
+
+import javax.net.ssl.SSLEngine
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class PemManagersProviderSpec extends AnyWordSpec with Matchers {
+
+  private def clientEngine(minTlsVersion: String): SSLEngine = {
+    // no CA path: trust the default JVM store, which is enough to inspect protocol negotiation
+    val sslContext = PemManagersProvider.createSslContext(None)
+    PemManagersProvider.configureClientEngine(sslContext.createSSLEngine("example.com", 443), minTlsVersion)
+  }
+
+  "protocolsAtOrAbove" should {
+    "keep only versions at or above the minimum" in {
+      val supported = Array("TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3")
+      PemManagersProvider.protocolsAtOrAbove("TLSv1.2", supported).toSeq shouldEqual Seq("TLSv1.2", "TLSv1.3")
+      PemManagersProvider.protocolsAtOrAbove("TLSv1.3", supported).toSeq shouldEqual Seq("TLSv1.3")
+      PemManagersProvider.protocolsAtOrAbove("TLSv1", supported).toSeq shouldEqual supported.toSeq
+    }
+
+    "never select non-TLS pseudo-protocols" in {
+      val supported = Array("SSLv2Hello", "SSLv3", "TLSv1.2", "TLSv1.3")
+      PemManagersProvider.protocolsAtOrAbove("TLSv1", supported).toSeq shouldEqual Seq("TLSv1.2", "TLSv1.3")
+    }
+
+    "reject an unknown minimum version" in {
+      val ex = intercept[IllegalArgumentException] {
+        PemManagersProvider.protocolsAtOrAbove("BAD_VERSION", Array("TLSv1.2"))
+      }
+      ex.getMessage should include("BAD_VERSION")
+    }
+
+    "reject a minimum no supported protocol satisfies" in {
+      val ex = intercept[IllegalArgumentException] {
+        PemManagersProvider.protocolsAtOrAbove("TLSv1.3", Array("TLSv1.1", "TLSv1.2"))
+      }
+      ex.getMessage should include("TLSv1.3")
+    }
+  }
+
+  "configureClientEngine" should {
+    // regression: the minimum used to be applied to a throwaway SSLParameters copy returned by
+    // SSLContext.getDefaultSSLParameters, so it never reached the connection at all
+    "actually restrict the protocols enabled on the engine" in {
+      val engine = clientEngine("TLSv1.3")
+      engine.getEnabledProtocols.toSeq shouldEqual Seq("TLSv1.3")
+      engine.getEnabledProtocols should not contain "TLSv1.2"
+    }
+
+    "enable every version at or above the minimum" in {
+      val engine = clientEngine("TLSv1.2")
+      val enabled = engine.getEnabledProtocols.toSeq
+      enabled should contain("TLSv1.2")
+      enabled.foreach(p => Seq("TLSv1.2", "TLSv1.3") should contain(p))
+    }
+
+    "put the engine in client mode and keep https endpoint identification" in {
+      val engine = clientEngine("TLSv1.2")
+      engine.getUseClientMode shouldBe true
+      // dropping this would silently disable hostname verification
+      engine.getSSLParameters.getEndpointIdentificationAlgorithm shouldEqual "https"
+    }
+
+    "reject an unknown minimum version" in {
+      intercept[IllegalArgumentException] {
+        clientEngine("BAD_VERSION")
+      }.getMessage should include("BAD_VERSION")
+    }
+  }
+
+  "createSslContext" should {
+    "support more than just the default protocol" in {
+      // the context itself must stay unrestricted; the engine is what pins the minimum
+      val engine = PemManagersProvider.createSslContext(None).createSSLEngine()
+      engine.getSupportedProtocols should contain("TLSv1.2")
+    }
+  }
+}

--- a/rolling-update-kubernetes/src/main/scala/org/apache/pekko/rollingupdate/kubernetes/KubernetesApiImpl.scala
+++ b/rolling-update-kubernetes/src/main/scala/org/apache/pekko/rollingupdate/kubernetes/KubernetesApiImpl.scala
@@ -438,6 +438,10 @@ PUTs must contain resourceVersions. Response:
  * INTERNAL API
  */
 @InternalApi private[pekko] object KubernetesApiImpl {
+
+  // this module has no tls-version setting of its own; keep in sync with the other Kubernetes modules
+  private val DefaultMinTlsVersion = "TLSv1.2"
+
   def apply(log: LoggingAdapter, k8sSettings: KubernetesSettings)(implicit system: ActorSystem) = {
     implicit val blockingDispatcher: ExecutionContext = system.dispatchers.lookup(DefaultBlockingDispatcherId)
     for {
@@ -479,8 +483,9 @@ PUTs must contain resourceVersions. Response:
    */
   private def clientHttpsConnectionContext(k8sSettings: KubernetesSettings): Option[HttpsConnectionContext] = {
     if (k8sSettings.secure) {
-      val sslContext = PemManagersProvider.createSslContext(k8sSettings.apiCaPath, "TLSv1.2")
-      Some(ConnectionContext.httpsClient(sslContext))
+      val sslContext = PemManagersProvider.createSslContext(k8sSettings.apiCaPath)
+      Some(ConnectionContext.httpsClient((host, port) =>
+        PemManagersProvider.configureClientEngine(sslContext.createSSLEngine(host, port), DefaultMinTlsVersion)))
     } else
       None
   }


### PR DESCRIPTION
### Motivation

`PemManagersProvider.createSslContext` took a `tlsVersion` and passed it straight to
`SSLContext.getInstance(tlsVersion)`. That name promises more than it delivers: the argument
selects a *context provider*, it does not pin the protocol actually negotiated. On JDK 17
`getInstance("TLSv1.3")` yields a context whose engines enable `[TLSv1.3, TLSv1.2]`, so the
only configuration that really restricted anything was the `TLSv1.2` default, and it did so by
also excluding TLSv1.3.

Renaming the parameter to `minTlsVersion` makes the intent explicit, and requires actually
enforcing a *minimum* rather than relying on a side effect of provider selection.

The enforcement point matters. An `SSLContext` has no mutable protocol list —
`getDefaultSSLParameters()` returns a fresh copy on every call and there is no
`setDefaultSSLParameters` — so a minimum can only be applied to the `SSLSocket` or `SSLEngine`
that carries the connection.

### Modification

- `createSslContext` no longer takes a version at all; it builds an unrestricted `"TLS"` context.
  Its overloads take `String` or `Option[String]` for the CA path, where `None` means the default
  JVM trust store (previously open-coded in `HttpContactPointBootstrap`).
- New `protocolsAtOrAbove(minTlsVersion, supportedProtocols)` returns the satisfying subset and
  throws `IllegalArgumentException` for an unknown version or an unsatisfiable minimum. Protocols
  outside the known TLS ordering (`SSLv3`, the `SSLv2Hello` pseudo-protocol) are never selected.
- New `configureClientEngine(engine, minTlsVersion)` applies that set via
  `engine.setEnabledProtocols`, sets client mode, and **re-applies
  `setEndpointIdentificationAlgorithm("https")`** — `ConnectionContext.httpsClient(sslContext)`
  sets that itself, so the engine-factory overload must restore it or hostname verification is
  silently lost.
- All four call sites (discovery-kubernetes-api, lease-kubernetes, rolling-update-kubernetes,
  management-cluster-bootstrap) now build their connection context from an engine factory.
- Settings fields are renamed `tlsVersion` -> `minTlsVersion`. **The `tls-version` config key is
  unchanged**, so no user configuration has to change; the reference.conf comments now say
  "minimum TLS version".

Effective behaviour change: with the default `tls-version = "TLSv1.2"`, TLSv1.3 is now enabled
as well and TLSv1.2 remains the floor. `tls-version = "TLSv1.3"` now genuinely excludes TLSv1.2,
which it did not before.

### Result

`tls-version` means what its name says: a floor, enforced on the connection. Configuring
`TLSv1.3` no longer silently continues to accept TLSv1.2.

### Tests

- New `management-pki/.../PemManagersProviderSpec` (9 tests) asserts on
  `getEnabledProtocols` of a real engine, plus client mode and the `https` endpoint
  identification algorithm.
- Directional: reinstating the original defect (applying the filter to the throwaway
  `getSSLParameters` copy) fails `"should actually restrict the protocols enabled on the engine"`
  with `List("TLSv1.3", "TLSv1.2") was not equal to List("TLSv1.3")`. The rest of the suite still
  passes, which is why the previous settings-only tests did not catch this.
- `HttpContactPointBootstrapSpec` gains a case asserting the configured minimum reaches the
  engine and that endpoint identification survives.
- `sbt "management-pki/test" "discovery-kubernetes-api/test" "lease-kubernetes/test"` — 115
  succeeded, 0 failed, 1 pending.
- `sbt "management-cluster-bootstrap/testOnly ...HttpContactPointBootstrapSpec"` — 6 succeeded.
- Scoped `mimaReportBinaryIssues` on management-pki, discovery-kubernetes-api, lease-kubernetes,
  management-cluster-bootstrap, rolling-update-kubernetes — all success.
- `scalafmt --mode diff-ref=origin/main` and `sbt +headerCheckAll` — clean.

### References

None - `createSslContext` gained its `tlsVersion` parameter earlier on this branch; this corrects
it before it ships.
