### PR TITLE
Only close AWS discovery clients that were actually built

### DIFF
--- a/discovery-aws-api/src/main/scala/org/apache/pekko/discovery/awsapi/ec2/Ec2TagBasedServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/org/apache/pekko/discovery/awsapi/ec2/Ec2TagBasedServiceDiscovery.scala
@@ -19,6 +19,7 @@ import com.amazonaws.retry.PredefinedRetryPolicies
 import com.amazonaws.services.ec2.model.{ DescribeInstancesRequest, Filter, Reservation }
 import com.amazonaws.services.ec2.{ AmazonEC2, AmazonEC2ClientBuilder }
 import org.apache.pekko
+import pekko.Done
 import pekko.actor.{ CoordinatedShutdown, ExtendedActorSystem }
 import pekko.annotation.InternalApi
 import pekko.discovery.ServiceDiscovery.{ Resolved, ResolvedTarget }
@@ -29,6 +30,7 @@ import pekko.pattern.after
 
 import java.net.InetAddress
 import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicReference
 import scala.annotation.tailrec
 import scala.collection.immutable.Seq
 import scala.concurrent.duration.FiniteDuration
@@ -100,10 +102,11 @@ final class Ec2TagBasedServiceDiscovery(system: ExtendedActorSystem) extends Ser
       }
   }
 
-  @volatile private var ec2ClientUsed = false
+  // holds the client once it has been successfully built, so that shutdown never forces
+  // (or re-attempts) the lazy initialisation
+  private val builtEc2Client = new AtomicReference[AmazonEC2]()
 
   private lazy val ec2Client: AmazonEC2 = {
-    ec2ClientUsed = true
     val clientConfiguration = clientConfigFqcn match {
       case Some(fqcn) =>
         getCustomClientConfigurationInstance(fqcn) match {
@@ -130,17 +133,19 @@ final class Ec2TagBasedServiceDiscovery(system: ExtendedActorSystem) extends Ser
       builder.withEndpointConfiguration(new EndpointConfiguration(endpoint, region))
     }
 
-    builder.build()
+    val client = builder.build()
+    builtEc2Client.set(client)
+    client
   }
 
   CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseServiceUnbind, "ec2-client-close") { () =>
-    if (ec2ClientUsed) {
-      Future {
-        ec2Client.shutdown()
-        pekko.Done
-      }(ec)
-    } else {
-      Future.successful(pekko.Done)
+    builtEc2Client.getAndSet(null) match {
+      case null   => Future.successful(Done)
+      case client =>
+        Future {
+          client.shutdown()
+          Done
+        }(ec)
     }
   }
 
@@ -149,7 +154,7 @@ final class Ec2TagBasedServiceDiscovery(system: ExtendedActorSystem) extends Ser
       client: AmazonEC2,
       filters: List[Filter],
       nextToken: Option[String],
-      accumulator: List[String] = Nil): List[String] = {
+      accumulator: Vector[String] = Vector.empty): Vector[String] = {
 
     val describeInstancesRequest = new DescribeInstancesRequest()
       .withFilters(filters.asJava) // withFilters is a set operation (i.e. calls setFilters, be careful with chaining)
@@ -157,11 +162,10 @@ final class Ec2TagBasedServiceDiscovery(system: ExtendedActorSystem) extends Ser
 
     val describeInstancesResult = client.describeInstances(describeInstancesRequest)
 
-    val ips: List[String] =
-      describeInstancesResult.getReservations.asScala
+    val ips =
+      describeInstancesResult.getReservations.asScala.view
         .flatMap((r: Reservation) => r.getInstances.asScala)
         .map(instance => instance.getPrivateIpAddress)
-        .toList
 
     val accumulatedIps = accumulator ++ ips
 

--- a/discovery-aws-api/src/main/scala/org/apache/pekko/discovery/awsapi/ecs/EcsServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/org/apache/pekko/discovery/awsapi/ecs/EcsServiceDiscovery.scala
@@ -15,8 +15,10 @@ package org.apache.pekko.discovery.awsapi.ecs
 
 import java.net.{ InetAddress, NetworkInterface }
 import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicReference
 
 import org.apache.pekko
+import pekko.Done
 import pekko.actor.{ ActorSystem, CoordinatedShutdown }
 import pekko.discovery.{ Lookup, ServiceDiscovery }
 import pekko.discovery.ServiceDiscovery.{ Resolved, ResolvedTarget }
@@ -48,10 +50,11 @@ final class EcsServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
   private val config = system.settings.config.getConfig("pekko.discovery.aws-api-ecs")
   private val cluster = config.getString("cluster")
 
-  @volatile private var ecsClientUsed = false
+  // holds the client once it has been successfully built, so that shutdown never forces
+  // (or re-attempts) the lazy initialisation
+  private val builtEcsClient = new AtomicReference[AmazonECS]()
 
-  private lazy val ecsClient = {
-    ecsClientUsed = true
+  private lazy val ecsClient: AmazonECS = {
     // we have our own retry/backoff mechanism, so we don't need EC2Client's in addition
     val clientConfiguration = new ClientConfiguration()
     clientConfiguration.setRetryPolicy(PredefinedRetryPolicies.NO_RETRY_POLICY)
@@ -63,20 +66,22 @@ final class EcsServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
       builder.withEndpointConfiguration(new EndpointConfiguration(endpoint, region))
     }
 
-    builder.build()
+    val client = builder.build()
+    builtEcsClient.set(client)
+    client
   }
 
   private implicit val ec: ExecutionContext =
     system.dispatchers.lookup("pekko.actor.default-blocking-io-dispatcher")
 
   CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseServiceUnbind, "ecs-client-close") { () =>
-    if (ecsClientUsed) {
-      Future {
-        ecsClient.shutdown()
-        pekko.Done
-      }(ec)
-    } else {
-      Future.successful(pekko.Done)
+    builtEcsClient.getAndSet(null) match {
+      case null   => Future.successful(Done)
+      case client =>
+        Future {
+          client.shutdown()
+          Done
+        }(ec)
     }
   }
 
@@ -123,7 +128,7 @@ object EcsServiceDiscovery {
         Left(s"Exactly one private address must be configured (found: $other).")
     }
 
-  private def resolveTasks(ecsClient: AmazonECS, cluster: String, serviceName: String): Seq[Task] = {
+  private[ecs] def resolveTasks(ecsClient: AmazonECS, cluster: String, serviceName: String): Seq[Task] = {
     val taskArns = listTaskArns(ecsClient, cluster, serviceName)
     val tasks = describeTasks(ecsClient, cluster, taskArns)
     tasks
@@ -134,7 +139,7 @@ object EcsServiceDiscovery {
       cluster: String,
       serviceName: String,
       pageTaken: Option[String] = None,
-      accumulator: Seq[String] = Seq.empty): Seq[String] = {
+      accumulator: Vector[String] = Vector.empty): Vector[String] = {
     val listTasksResult = ecsClient.listTasks(
       new ListTasksRequest()
         .withCluster(cluster)
@@ -157,12 +162,15 @@ object EcsServiceDiscovery {
   }
 
   private def describeTasks(ecsClient: AmazonECS, cluster: String, taskArns: Seq[String]): Seq[Task] =
-    for {
+    taskArns
       // Each DescribeTasksRequest can contain at most 100 task ARNs.
-      group <- taskArns.grouped(100).toSeq
-      tasks = ecsClient.describeTasks(
-        new DescribeTasksRequest().withCluster(cluster).withTasks(group.asJava))
-      task <- tasks.getTasks.asScala
-    } yield task
+      .grouped(100)
+      .flatMap { group =>
+        ecsClient
+          .describeTasks(new DescribeTasksRequest().withCluster(cluster).withTasks(group.asJava))
+          .getTasks
+          .asScala
+      }
+      .toList
 
 }

--- a/discovery-aws-api/src/test/scala/org/apache/pekko/discovery/awsapi/ec2/Ec2ClientShutdownSpec.scala
+++ b/discovery-aws-api/src/test/scala/org/apache/pekko/discovery/awsapi/ec2/Ec2ClientShutdownSpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.discovery.awsapi.ec2
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import com.amazonaws.ClientConfiguration
+import com.typesafe.config.ConfigFactory
+import org.apache.pekko
+import pekko.actor.{ ActorSystem, CoordinatedShutdown, ExtendedActorSystem }
+import pekko.discovery.Lookup
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+object Ec2ClientShutdownSpec {
+
+  val configurationAttempts = new AtomicInteger(0)
+
+  // Fails to construct, so that `ec2Client` always fails to initialise. A Scala `lazy val` whose
+  // initialiser throws stays uninitialised, so any later access re-runs the initialiser.
+  class FailingClientConfiguration extends ClientConfiguration {
+    private val attempt = configurationAttempts.incrementAndGet()
+    require(attempt < 0, "cannot build a client configuration")
+  }
+
+}
+
+class Ec2ClientShutdownSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach {
+
+  import Ec2ClientShutdownSpec._
+
+  private def newSystem(): ExtendedActorSystem =
+    ActorSystem(
+      "Ec2ClientShutdownSpec",
+      ConfigFactory
+        .parseString(
+          s"""pekko.discovery.aws-api-ec2-tag-based.client-config = "${classOf[
+              FailingClientConfiguration].getName}"""")
+        .withFallback(ConfigFactory.load())).asInstanceOf[ExtendedActorSystem]
+
+  override def beforeEach(): Unit = configurationAttempts.set(0)
+
+  "Ec2TagBasedServiceDiscovery" should {
+
+    "not create the EC2 client during shutdown when discovery was never used" in {
+      val system = newSystem()
+      new Ec2TagBasedServiceDiscovery(system)
+
+      Await.result(CoordinatedShutdown(system).run(CoordinatedShutdown.UnknownReason), 30.seconds)
+
+      configurationAttempts.get() should ===(0)
+    }
+
+    "not re-attempt EC2 client creation during shutdown when creation previously failed" in {
+      val system = newSystem()
+      val discovery = new Ec2TagBasedServiceDiscovery(system)
+
+      Await.ready(discovery.lookup(Lookup("my-service"), 10.seconds), 30.seconds)
+      configurationAttempts.get() should ===(1)
+
+      Await.result(CoordinatedShutdown(system).run(CoordinatedShutdown.UnknownReason), 30.seconds)
+
+      configurationAttempts.get() should ===(1)
+    }
+
+  }
+
+}

--- a/discovery-aws-api/src/test/scala/org/apache/pekko/discovery/awsapi/ecs/EcsResolveTasksSpec.scala
+++ b/discovery-aws-api/src/test/scala/org/apache/pekko/discovery/awsapi/ecs/EcsResolveTasksSpec.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.discovery.awsapi.ecs
+
+import com.amazonaws.services.ecs.AbstractAmazonECS
+import com.amazonaws.services.ecs.model.{
+  DescribeTasksRequest,
+  DescribeTasksResult,
+  ListTasksRequest,
+  ListTasksResult,
+  Task
+}
+import org.apache.pekko.discovery.awsapi.ecs.EcsServiceDiscovery.resolveTasks
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.collection.mutable.ListBuffer
+import scala.jdk.CollectionConverters._
+
+object EcsResolveTasksSpec {
+
+  // Returns `taskArns` over pages of `pageSize`, and echoes back a Task for every ARN it is asked about.
+  class StubAmazonECS(taskArns: Seq[String], pageSize: Int) extends AbstractAmazonECS {
+
+    val describeTasksBatchSizes = ListBuffer.empty[Int]
+
+    private val pages = {
+      val grouped = taskArns.grouped(pageSize).toVector
+      if (grouped.isEmpty) Vector(Seq.empty[String]) else grouped
+    }
+
+    override def listTasks(request: ListTasksRequest): ListTasksResult = {
+      val pageIndex = Option(request.getNextToken).map(_.toInt).getOrElse(0)
+      val result = new ListTasksResult().withTaskArns(pages(pageIndex).asJava)
+      if (pageIndex + 1 < pages.size) result.withNextToken((pageIndex + 1).toString) else result
+    }
+
+    override def describeTasks(request: DescribeTasksRequest): DescribeTasksResult = {
+      val arns = request.getTasks.asScala.toList
+      describeTasksBatchSizes += arns.size
+      new DescribeTasksResult().withTasks(arns.map(arn => new Task().withTaskArn(arn)).asJava)
+    }
+
+  }
+
+}
+
+class EcsResolveTasksSpec extends AnyWordSpec with Matchers {
+
+  import EcsResolveTasksSpec._
+
+  private val arns = (1 to 250).map(i => s"arn:task/$i").toList
+
+  "EcsServiceDiscovery.resolveTasks" should {
+
+    "accumulate every task ARN across paginated listTasks responses" in {
+      val ecsClient = new StubAmazonECS(arns, pageSize = 60)
+
+      val tasks = resolveTasks(ecsClient, "default", "my-service")
+
+      tasks.map(_.getTaskArn) should ===(arns)
+    }
+
+    "split describeTasks into batches of at most 100 ARNs" in {
+      val ecsClient = new StubAmazonECS(arns, pageSize = 250)
+
+      resolveTasks(ecsClient, "default", "my-service") should have size 250
+      ecsClient.describeTasksBatchSizes.toList should ===(List(100, 100, 50))
+    }
+
+    "not call describeTasks when there are no task ARNs" in {
+      val ecsClient = new StubAmazonECS(Seq.empty, pageSize = 100)
+
+      resolveTasks(ecsClient, "default", "my-service") should be(empty)
+      ecsClient.describeTasksBatchSizes.toList should be(empty)
+    }
+
+  }
+
+}


### PR DESCRIPTION
### Motivation

Follow-up to #907.

The `ec2ClientUsed` / `ecsClientUsed` flags added in #907 are set at the *top* of the lazy client initialiser, before the client exists:

```scala
private lazy val ec2Client: AmazonEC2 = {
  ec2ClientUsed = true          // <-- before the client is built
  ...
  builder.build()
}
```

A Scala `lazy val` whose initialiser throws stays uninitialised and is re-evaluated on the next access. So if `builder.build()` fails, or the custom `client-config` FQCN cannot be instantiated (`throw new Exception(s"Could not create instance of '$fqcn'", ex)`), we end up with `ec2ClientUsed == true` and no client. The `PhaseServiceUnbind` task then calls `ec2Client.shutdown()`, re-enters the initialiser and throws again — which is precisely the shutdown-time client creation the flag was added to avoid (see @He-Pin's review comment on #907). Setting the flag before `builder.build()` returns also leaves a window where shutdown observes `true` while another thread is still constructing the client.

Separately, the two collection changes in #907 are not the optimisations the description claimed:

- `taskArns.grouped(100).toSeq` — `IterableOnceOps.toSeq` is `immutable.Seq.from(this)`, i.e. strict, and `List` is the default `immutable.Seq`. This materialises exactly like the `.toList` it replaced.
- EC2 `getInstances` — `java.util.List.asScala` yields a strict `mutable.Buffer`, not a lazy view, so `flatMap` then `map` build two intermediate buffers before `.toList`. No fewer allocations than the original.

Both paginated loops also do `accumulator ++ page` per page (`List` in EC2, `immutable.Seq` in ECS), which is O(pages²) copying.

### Modification

- Replace both `@volatile var` flags with an `AtomicReference` that is populated **after** `builder.build()` succeeds. The shutdown task closes whatever client it finds there and returns `Done` when it is null, so it never touches the lazy val.
- EC2 `getInstances`: use `.view` so `flatMap`/`map` are genuinely lazy, and accumulate into a `Vector`.
- ECS `describeTasks`: `flatMap` straight off the `grouped` iterator instead of materialising the groups first.
- ECS `listTaskArns`: accumulate into a `Vector` so appends are amortised constant time.
- New `Ec2ClientShutdownSpec` and `EcsResolveTasksSpec`. `EcsServiceDiscovery.resolveTasks` is relaxed from `private` to `private[ecs]` so the latter can drive it — a new method in bytecode, so MiMa-clean.

### Result

Shutdown never creates, or re-attempts to create, an AWS client — including after a failed creation. Pagination is linear in the number of pages rather than quadratic, and the EC2 chain allocates one list instead of three.

### Tests

- `sbt "discovery-aws-api/test"` — 8 succeeded, 0 failed.
- Directional check: `sbt "discovery-aws-api/testOnly *Ec2ClientShutdownSpec"` with `Ec2TagBasedServiceDiscovery.scala` reverted to `main` — *"should not re-attempt EC2 client creation during shutdown when creation previously failed"* **FAILED** (2 configuration attempts instead of 1). Passes with the fix.
- `sbt "+discovery-aws-api/mimaReportBinaryIssues"` — success.
- `sbt "discovery-aws-api/scalafmt" "discovery-aws-api/Test/scalafmt"` and `sbt headerCreateAll` — clean. `sortImports` is not a task in this build (only `javafmtSortImports`); no Java sources changed.
- Not exercised against live AWS — no account available. The specs stub `AbstractAmazonECS` and `ClientConfiguration` so no credentials, region or network access are needed.

### References

Refs #907
