### PR TITLE
chore: remove leftover Scala 2.12 idioms

### DIFF
--- a/discovery-aws-api-async/src/main/scala/org/apache/pekko/discovery/awsapi/ecs/AsyncEcsServiceDiscovery.scala
+++ b/discovery-aws-api-async/src/main/scala/org/apache/pekko/discovery/awsapi/ecs/AsyncEcsServiceDiscovery.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.discovery.awsapi.ecs
 import java.net.InetAddress
 import java.util.concurrent.TimeoutException
 
-import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.jdk.CollectionConverters._

--- a/discovery-aws-api-async/src/main/scala/org/apache/pekko/discovery/awsapi/ecs/AsyncEcsTaskSetDiscovery.scala
+++ b/discovery-aws-api-async/src/main/scala/org/apache/pekko/discovery/awsapi/ecs/AsyncEcsTaskSetDiscovery.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.discovery.awsapi.ecs
 import java.net.InetAddress
 import java.util.concurrent.TimeoutException
 
-import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.jdk.CollectionConverters._

--- a/discovery-aws-api/src/main/scala/org/apache/pekko/discovery/awsapi/ec2/Ec2TagBasedServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/org/apache/pekko/discovery/awsapi/ec2/Ec2TagBasedServiceDiscovery.scala
@@ -30,7 +30,6 @@ import pekko.pattern.after
 import java.net.InetAddress
 import java.util.concurrent.TimeoutException
 import scala.annotation.tailrec
-import scala.collection.immutable.Seq
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.jdk.CollectionConverters._

--- a/discovery-aws-api/src/main/scala/org/apache/pekko/discovery/awsapi/ecs/EcsServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/org/apache/pekko/discovery/awsapi/ecs/EcsServiceDiscovery.scala
@@ -31,7 +31,6 @@ import com.amazonaws.services.ecs.model.{ DescribeTasksRequest, DesiredStatus, L
 import com.amazonaws.services.ecs.{ AmazonECS, AmazonECSClientBuilder }
 
 import scala.annotation.tailrec
-import scala.collection.immutable.Seq
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._

--- a/discovery-consul/src/main/scala/org/apache/pekko/discovery/consul/ConsulServiceDiscovery.scala
+++ b/discovery-consul/src/main/scala/org/apache/pekko/discovery/consul/ConsulServiceDiscovery.scala
@@ -34,7 +34,6 @@ import java.security.cert.CertificateFactory
 import java.util
 import java.util.concurrent.TimeoutException
 import javax.net.ssl.{ SSLContext, TrustManagerFactory }
-import scala.collection.immutable.Seq
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.jdk.CollectionConverters._
@@ -107,7 +106,7 @@ class ConsulServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
         Future(extractResolvedTargetFromCatalogService(catalogService))(blockingEc)
       }
     } yield resolvedTargets
-    consulResult.map(targets => Resolved(name, scala.collection.immutable.Seq(targets: _*)))
+    consulResult.map(targets => Resolved(name, targets))
   }
 
   private def extractResolvedTargetFromCatalogService(catalogService: CatalogService) = {

--- a/discovery-kubernetes-api/src/main/scala/org/apache/pekko/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/org/apache/pekko/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
@@ -18,8 +18,6 @@ import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeoutException
 import java.nio.file.{ Files, Paths }
 
-import scala.collection.immutable
-import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
@@ -59,7 +57,7 @@ object KubernetesApiServiceDiscovery {
       podNamespace: String,
       podDomain: String,
       rawIp: Boolean,
-      containerName: Option[String]): immutable.Seq[ResolvedTarget] =
+      containerName: Option[String]): Seq[ResolvedTarget] =
     for {
       item <- podList.items
       if item.metadata.flatMap(_.deletionTimestamp).isEmpty
@@ -240,7 +238,7 @@ class KubernetesApiServiceDiscovery(settings: Settings)(
       val query = Uri.Query("labelSelector" -> labelSelector)
       val uri = Uri.from(scheme = "https", host = host, port = port).withPath(path).withQuery(query)
 
-      val authHeaders = immutable.Seq(Authorization(OAuth2BearerToken(token)))
+      val authHeaders = Seq(Authorization(OAuth2BearerToken(token)))
       val acceptEncodingHeader = HttpEncodings.getForKey(settings.httpRequestAcceptEncoding)
         .map(httpEncoding => AcceptEncoding.create(httpEncoding))
       HttpRequest(uri = uri, headers = authHeaders ++ acceptEncodingHeader)

--- a/discovery-kubernetes-api/src/main/scala/org/apache/pekko/discovery/kubernetes/PodList.scala
+++ b/discovery-kubernetes-api/src/main/scala/org/apache/pekko/discovery/kubernetes/PodList.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.discovery.kubernetes
 
-import scala.collection.immutable
 import org.apache.pekko.annotation.InternalApi
 
 /**
@@ -24,15 +23,15 @@ import org.apache.pekko.annotation.InternalApi
 
   final case class ContainerPort(name: Option[String], containerPort: Int)
 
-  final case class Container(name: String, ports: Option[immutable.Seq[ContainerPort]])
+  final case class Container(name: String, ports: Option[Seq[ContainerPort]])
 
-  final case class PodSpec(containers: immutable.Seq[Container])
+  final case class PodSpec(containers: Seq[Container])
 
   final case class ContainerStatus(name: String, state: Map[String, Unit])
 
   final case class PodStatus(
       podIP: Option[String],
-      containerStatuses: Option[immutable.Seq[ContainerStatus]],
+      containerStatuses: Option[Seq[ContainerStatus]],
       phase: Option[String])
 
   final case class Pod(spec: Option[PodSpec], status: Option[PodStatus], metadata: Option[Metadata])
@@ -41,4 +40,4 @@ import org.apache.pekko.annotation.InternalApi
 /**
  * INTERNAL API
  */
-@InternalApi private[kubernetes] final case class PodList(items: immutable.Seq[PodList.Pod])
+@InternalApi private[kubernetes] final case class PodList(items: Seq[PodList.Pod])

--- a/discovery-marathon-api/src/main/scala/org/apache/pekko/discovery/marathon/AppList.scala
+++ b/discovery-marathon-api/src/main/scala/org/apache/pekko/discovery/marathon/AppList.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.discovery.marathon
 
-import scala.collection.immutable.Seq
-
 object AppList {
   case class App(container: Option[Container], portDefinitions: Option[Seq[PortDefinition]], tasks: Option[Seq[Task]])
   case class Container(portMappings: Option[Seq[PortMapping]], docker: Option[Docker])

--- a/discovery-marathon-api/src/main/scala/org/apache/pekko/discovery/marathon/MarathonApiServiceDiscovery.scala
+++ b/discovery-marathon-api/src/main/scala/org/apache/pekko/discovery/marathon/MarathonApiServiceDiscovery.scala
@@ -20,7 +20,6 @@ import pekko.http.scaladsl._
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.unmarshalling.Unmarshal
 
-import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Try

--- a/lease-kubernetes-int-test/src/test/scala/org/apache/pekko/coordination/lease/kubernetes/LeaseContentionSpec.scala
+++ b/lease-kubernetes-int-test/src/test/scala/org/apache/pekko/coordination/lease/kubernetes/LeaseContentionSpec.scala
@@ -11,7 +11,6 @@ package org.apache.pekko.coordination.lease.kubernetes
 
 import java.util.concurrent.Executors
 
-import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -76,7 +75,7 @@ class LeaseContentionSpec extends TestKit(ActorSystem("LeaseContentionSpec",
       val nrClients = 30
       implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(nrClients)) // too many = HTTP request queue of pool fills up
       // could make this more contended with a countdown latch so they all start at the same time
-      val leases: immutable.Seq[(String, Boolean)] = Future.sequence((0 until nrClients).map(i => {
+      val leases: Seq[(String, Boolean)] = Future.sequence((0 until nrClients).map(i => {
         val clientName = s"client$i"
         val lease = underTest.getLease(lease1, KubernetesLease.configPath, clientName)
         Future {

--- a/lease-kubernetes/src/main/scala/org/apache/pekko/coordination/lease/kubernetes/internal/AbstractKubernetesApiImpl.scala
+++ b/lease-kubernetes/src/main/scala/org/apache/pekko/coordination/lease/kubernetes/internal/AbstractKubernetesApiImpl.scala
@@ -31,7 +31,6 @@ import pekko.util.ByteString
 
 import java.nio.file.{ Files, Paths }
 import javax.net.ssl.SSLContext
-import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.util.control.NonFatal
 
@@ -69,7 +68,7 @@ import scala.util.control.NonFatal
     _.getOrElse(""))(ExecutionContext.parasitic)
   private def headers() = if (settings.secure) {
     apiToken().map { token =>
-      immutable.Seq(Authorization(OAuth2BearerToken(token)))
+      Seq(Authorization(OAuth2BearerToken(token)))
     }(ExecutionContext.parasitic)
   } else
     Future.successful(Nil)

--- a/management-cluster-bootstrap/src/main/scala/org/apache/pekko/management/cluster/bootstrap/internal/BootstrapCoordinator.scala
+++ b/management-cluster-bootstrap/src/main/scala/org/apache/pekko/management/cluster/bootstrap/internal/BootstrapCoordinator.scala
@@ -85,7 +85,7 @@ private[pekko] object BootstrapCoordinator {
       lookup: Lookup,
       fallbackPort: Int,
       filterOnFallbackPort: Boolean,
-      contactPoints: immutable.Seq[ResolvedTarget]): immutable.Iterable[ResolvedTarget] = {
+      contactPoints: Seq[ResolvedTarget]): immutable.Iterable[ResolvedTarget] = {
 
     // if the user has specified a port name in the search, don't do any filtering and assume it
     // is handled in the service discovery mechanism
@@ -93,8 +93,8 @@ private[pekko] object BootstrapCoordinator {
       contactPoints
     } else {
       contactPoints.groupBy(_.host).flatMap {
-        case (_, immutable.Seq(singleResult)) =>
-          immutable.Seq(singleResult)
+        case (_, Seq(singleResult)) =>
+          Seq(singleResult)
         case (_, multipleResults) =>
           if (multipleResults.exists(_.port.isDefined)) {
             multipleResults.filter(_.port.contains(fallbackPort))

--- a/management-cluster-http/src/main/scala/org/apache/pekko/management/cluster/ClusterHttpManagementProtocol.scala
+++ b/management-cluster-http/src/main/scala/org/apache/pekko/management/cluster/ClusterHttpManagementProtocol.scala
@@ -20,7 +20,7 @@ import spray.json.{ DefaultJsonProtocol, RootJsonFormat }
 
 import scala.collection.immutable
 
-final case class ClusterUnreachableMember(node: String, observedBy: immutable.Seq[String])
+final case class ClusterUnreachableMember(node: String, observedBy: Seq[String])
 final case class ClusterMember(node: String, nodeUid: String, status: String, roles: Set[String])
 object ClusterMember {
   implicit val clusterMemberOrdering: Ordering[ClusterMember] = Ordering.by(_.node)
@@ -28,14 +28,14 @@ object ClusterMember {
 final case class ClusterMembers(
     selfNode: String,
     members: Set[ClusterMember],
-    unreachable: immutable.Seq[ClusterUnreachableMember],
+    unreachable: Seq[ClusterUnreachableMember],
     leader: Option[String],
     oldest: Option[String],
     oldestPerRole: Map[String, String])
 final case class ClusterHttpManagementMessage(message: String)
 final case class ShardEntityTypeKeys(entityTypeKeys: immutable.Set[String])
 final case class ShardRegionInfo(shardId: String, numEntities: Int)
-final case class ShardDetails(regions: immutable.Seq[ShardRegionInfo])
+final case class ShardDetails(regions: Seq[ShardRegionInfo])
 
 /** INTERNAL API */
 @InternalApi private[pekko] sealed trait ClusterHttpManagementMemberOperation

--- a/management-cluster-http/src/test/scala/org/apache/pekko/cluster/http/management/scaladsl/ClusterHttpManagementRoutesSpec.scala
+++ b/management-cluster-http/src/test/scala/org/apache/pekko/cluster/http/management/scaladsl/ClusterHttpManagementRoutesSpec.scala
@@ -41,7 +41,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{ Millis, Seconds, Span }
 import org.scalatest.wordspec.AnyWordSpecLike
 
-import scala.collection.immutable._
+import scala.collection.immutable.SortedSet
 import scala.concurrent.Promise
 
 class ClusterHttpManagementRoutesSpec

--- a/management/src/main/scala/org/apache/pekko/management/HealthCheckSettings.scala
+++ b/management/src/main/scala/org/apache/pekko/management/HealthCheckSettings.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.management
 
 import com.typesafe.config.Config
 
-import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
 import scala.jdk.CollectionConverters._
 import scala.jdk.DurationConverters._
@@ -119,9 +118,9 @@ object HealthCheckSettings {
  * @param checkTimeout how long to wait for all health checks to complete
  */
 final class HealthCheckSettings(
-    val startupChecks: immutable.Seq[NamedHealthCheck],
-    val readinessChecks: immutable.Seq[NamedHealthCheck],
-    val livenessChecks: immutable.Seq[NamedHealthCheck],
+    val startupChecks: Seq[NamedHealthCheck],
+    val readinessChecks: Seq[NamedHealthCheck],
+    val livenessChecks: Seq[NamedHealthCheck],
     val startupPath: String,
     val readinessPath: String,
     val livenessPath: String,
@@ -129,8 +128,8 @@ final class HealthCheckSettings(
 
   @deprecated("Use constructor that takes `startupChecks` and `startupPath` parameters instead", "1.1.0")
   def this(
-      readinessChecks: immutable.Seq[NamedHealthCheck],
-      livenessChecks: immutable.Seq[NamedHealthCheck],
+      readinessChecks: Seq[NamedHealthCheck],
+      livenessChecks: Seq[NamedHealthCheck],
       readinessPath: String,
       livenessPath: String,
       checkTimeout: FiniteDuration

--- a/management/src/main/scala/org/apache/pekko/management/PekkoManagementSettings.scala
+++ b/management/src/main/scala/org/apache/pekko/management/PekkoManagementSettings.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.management
 import java.net.InetAddress
 import java.util.Optional
 
-import scala.collection.immutable
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.jdk.CollectionConverters._
 import scala.jdk.DurationConverters._
@@ -62,7 +61,7 @@ final class PekkoManagementSettings(val config: Config) {
     val BasePath: Option[String] =
       Option(cc.getString("base-path")).flatMap(it => if (it.trim == "") None else Some(it))
 
-    val RouteProviders: immutable.Seq[NamedRouteProvider] = {
+    val RouteProviders: Seq[NamedRouteProvider] = {
       def validFQCN(value: Any) = {
         value != null &&
         value != "null" &&

--- a/management/src/main/scala/org/apache/pekko/management/internal/HealthChecksImpl.scala
+++ b/management/src/main/scala/org/apache/pekko/management/internal/HealthChecksImpl.scala
@@ -28,7 +28,6 @@ import pekko.management.javadsl.{ ReadinessCheckSetup => JReadinessCheckSetup }
 import pekko.management.javadsl.{ StartupCheckSetup => JStartupCheckSetup }
 import pekko.management.scaladsl.{ HealthChecks, LivenessCheckSetup, ReadinessCheckSetup, StartupCheckSetup }
 
-import scala.collection.immutable
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
 import scala.jdk.FutureConverters._
@@ -59,7 +58,7 @@ final private[pekko] class HealthChecksImpl(system: ExtendedActorSystem, setting
     "Loading liveness checks [{}]",
     settings.livenessChecks.map(a => a.name -> a.fullyQualifiedClassName).mkString(", "))
 
-  private val startupChecks: immutable.Seq[HealthCheck] = {
+  private val startupChecks: Seq[HealthCheck] = {
     val fromScaladslSetup = system.settings.setup.get[StartupCheckSetup] match {
       case None        => Nil
       case Some(setup) => setup.createHealthChecks(system)
@@ -72,7 +71,7 @@ final private[pekko] class HealthChecksImpl(system: ExtendedActorSystem, setting
     fromConfig ++ fromScaladslSetup ++ fromJavadslSetup
   }
 
-  private val readiness: immutable.Seq[HealthCheck] = {
+  private val readiness: Seq[HealthCheck] = {
     val fromScaladslSetup = system.settings.setup.get[ReadinessCheckSetup] match {
       case None        => Nil
       case Some(setup) => setup.createHealthChecks(system)
@@ -85,7 +84,7 @@ final private[pekko] class HealthChecksImpl(system: ExtendedActorSystem, setting
     fromConfig ++ fromScaladslSetup ++ fromJavadslSetup
   }
 
-  private val liveness: immutable.Seq[HealthCheck] = {
+  private val liveness: Seq[HealthCheck] = {
     val fromScaladslSetup = system.settings.setup.get[LivenessCheckSetup] match {
       case None        => Nil
       case Some(setup) => setup.createHealthChecks(system)
@@ -99,7 +98,7 @@ final private[pekko] class HealthChecksImpl(system: ExtendedActorSystem, setting
   }
 
   private def convertSuppliersToScala(
-      suppliers: JList[Supplier[CompletionStage[JBoolean]]]): immutable.Seq[HealthCheck] = {
+      suppliers: JList[Supplier[CompletionStage[JBoolean]]]): Seq[HealthCheck] = {
     suppliers.asScala.toList.map(convertSupplierToScala)
   }
 
@@ -111,7 +110,7 @@ final private[pekko] class HealthChecksImpl(system: ExtendedActorSystem, setting
     system.dynamicAccess
       .createInstanceFor[HealthCheck](
         fqcn,
-        immutable.Seq((classOf[ActorSystem], system)))
+        Seq((classOf[ActorSystem], system)))
       .recoverWith {
         case _: NoSuchMethodException =>
           system.dynamicAccess.createInstanceFor[HealthCheck](fqcn, Nil)
@@ -122,7 +121,7 @@ final private[pekko] class HealthChecksImpl(system: ExtendedActorSystem, setting
     system.dynamicAccess
       .createInstanceFor[Supplier[CompletionStage[JBoolean]]](
         fqcn,
-        immutable.Seq((classOf[ActorSystem], system)))
+        Seq((classOf[ActorSystem], system)))
       .recoverWith {
         case _: NoSuchMethodException =>
           system.dynamicAccess.createInstanceFor[Supplier[CompletionStage[JBoolean]]](fqcn, Nil)
@@ -131,7 +130,7 @@ final private[pekko] class HealthChecksImpl(system: ExtendedActorSystem, setting
   }
 
   private def load(
-      checks: immutable.Seq[NamedHealthCheck]): immutable.Seq[HealthCheck] = {
+      checks: Seq[NamedHealthCheck]): Seq[HealthCheck] = {
     checks
       .map(namedHealthCheck =>
         tryLoadScalaHealthCheck(namedHealthCheck.fullyQualifiedClassName).recoverWith {
@@ -202,7 +201,7 @@ final private[pekko] class HealthChecksImpl(system: ExtendedActorSystem, setting
     Future.fromTry(Try(check())).flatMap(identity)
   }
 
-  private def check(checks: immutable.Seq[HealthCheck]): Future[Either[String, Unit]] = {
+  private def check(checks: Seq[HealthCheck]): Future[Either[String, Unit]] = {
     val spawnedChecks: Seq[Future[Either[String, Unit]]] = checks.map { check =>
       val checkName = check.getClass.getName
       // Create a per-check timeout so each check gets its own timer,

--- a/management/src/main/scala/org/apache/pekko/management/scaladsl/HealthChecks.scala
+++ b/management/src/main/scala/org/apache/pekko/management/scaladsl/HealthChecks.scala
@@ -12,7 +12,6 @@
  */
 
 package org.apache.pekko.management.scaladsl
-import scala.collection.immutable
 import scala.concurrent.Future
 import org.apache.pekko
 import pekko.actor.ActorSystem
@@ -77,7 +76,7 @@ object StartupCheckSetup {
   /**
    * Programmatic definition of startup checks
    */
-  def apply(createHealthChecks: ActorSystem => immutable.Seq[HealthChecks.HealthCheck]): StartupCheckSetup = {
+  def apply(createHealthChecks: ActorSystem => Seq[HealthChecks.HealthCheck]): StartupCheckSetup = {
     new StartupCheckSetup(createHealthChecks)
   }
 
@@ -87,14 +86,14 @@ object StartupCheckSetup {
  * Setup for startup checks, constructor is *Internal API*, use factories in [[StartupCheckSetup]]
  */
 final class StartupCheckSetup private (
-    val createHealthChecks: ActorSystem => immutable.Seq[HealthChecks.HealthCheck]) extends Setup
+    val createHealthChecks: ActorSystem => Seq[HealthChecks.HealthCheck]) extends Setup
 
 object ReadinessCheckSetup {
 
   /**
    * Programmatic definition of readiness checks
    */
-  def apply(createHealthChecks: ActorSystem => immutable.Seq[HealthChecks.HealthCheck]): ReadinessCheckSetup = {
+  def apply(createHealthChecks: ActorSystem => Seq[HealthChecks.HealthCheck]): ReadinessCheckSetup = {
     new ReadinessCheckSetup(createHealthChecks)
   }
 
@@ -104,14 +103,14 @@ object ReadinessCheckSetup {
  * Setup for readiness checks, constructor is *Internal API*, use factories in [[ReadinessCheckSetup]]
  */
 final class ReadinessCheckSetup private (
-    val createHealthChecks: ActorSystem => immutable.Seq[HealthChecks.HealthCheck]) extends Setup
+    val createHealthChecks: ActorSystem => Seq[HealthChecks.HealthCheck]) extends Setup
 
 object LivenessCheckSetup {
 
   /**
    * Programmatic definition of liveness checks
    */
-  def apply(createHealthChecks: ActorSystem => immutable.Seq[HealthChecks.HealthCheck]): LivenessCheckSetup = {
+  def apply(createHealthChecks: ActorSystem => Seq[HealthChecks.HealthCheck]): LivenessCheckSetup = {
     new LivenessCheckSetup(createHealthChecks)
   }
 
@@ -121,4 +120,4 @@ object LivenessCheckSetup {
  * Setup for liveness checks, constructor is *Internal API*, use factories in [[LivenessCheckSetup]]
  */
 final class LivenessCheckSetup private (
-    val createHealthChecks: ActorSystem => immutable.Seq[HealthChecks.HealthCheck]) extends Setup
+    val createHealthChecks: ActorSystem => Seq[HealthChecks.HealthCheck]) extends Setup

--- a/management/src/main/scala/org/apache/pekko/management/scaladsl/PekkoManagement.scala
+++ b/management/src/main/scala/org/apache/pekko/management/scaladsl/PekkoManagement.scala
@@ -38,7 +38,6 @@ import java.util.Optional
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.annotation.tailrec
-import scala.collection.immutable
 import scala.concurrent.{ Future, Promise }
 import scala.jdk.FutureConverters._
 import scala.jdk.OptionConverters._
@@ -78,7 +77,7 @@ final class PekkoManagement(implicit private[pekko] val system: ExtendedActorSys
 
   import system.dispatcher
 
-  private val routeProviders: immutable.Seq[ManagementRouteProvider] = loadRouteProviders()
+  private val routeProviders: Seq[ManagementRouteProvider] = loadRouteProviders()
 
   private val bindingFuture = new AtomicReference[(ManagementRouteProviderSettings, Future[Http.ServerBinding])]()
   private val selfUriPromise = Promise[Uri]()
@@ -248,7 +247,7 @@ final class PekkoManagement(implicit private[pekko] val system: ExtendedActorSys
     } else stop() // retry, CAS was not successful, someone else completed the stop()
   }
 
-  private def loadRouteProviders(): immutable.Seq[ManagementRouteProvider] = {
+  private def loadRouteProviders(): Seq[ManagementRouteProvider] = {
     val dynamicAccess = system.dynamicAccess
 
     // since often the providers are Pekko extensions, we initialize them here as the ActorSystem would otherwise

--- a/management/src/test/scala/org/apache/pekko/management/HealthChecksSpec.scala
+++ b/management/src/test/scala/org/apache/pekko/management/HealthChecksSpec.scala
@@ -26,7 +26,6 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
-import scala.collection.{ immutable => im }
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
 import scala.util.control.NoStackTrace
@@ -114,8 +113,8 @@ class HealthChecksSpec
   val DoesNotExist = NamedHealthCheck("DoesNotExist", "org.apache.pekko.management.DoesNotExist")
   val CtrExceptionCheck = NamedHealthCheck("CtrExceptionCheck", "org.apache.pekko.management.CtrException")
 
-  def settings(startup: im.Seq[NamedHealthCheck], readiness: im.Seq[NamedHealthCheck],
-      liveness: im.Seq[NamedHealthCheck]) =
+  def settings(startup: Seq[NamedHealthCheck], readiness: Seq[NamedHealthCheck],
+      liveness: Seq[NamedHealthCheck]) =
     new HealthCheckSettings(startup, readiness, liveness, "startup", "ready", "alive", 500.millis)
 
   "HealthCheck" should {
@@ -132,9 +131,9 @@ class HealthChecksSpec
       val checks = HealthChecks(
         eas,
         settings(
-          im.Seq(OkCheck),
-          im.Seq(OkCheck),
-          im.Seq(OkCheck)))
+          Seq(OkCheck),
+          Seq(OkCheck),
+          Seq(OkCheck)))
       checks.startupResult().futureValue shouldEqual Right(())
       checks.aliveResult().futureValue shouldEqual Right(())
       checks.readyResult().futureValue shouldEqual Right(())
@@ -146,9 +145,9 @@ class HealthChecksSpec
       val checks = HealthChecks(
         eas,
         settings(
-          im.Seq(NoArgsCtrCheck),
-          im.Seq(NoArgsCtrCheck),
-          im.Seq(NoArgsCtrCheck)))
+          Seq(NoArgsCtrCheck),
+          Seq(NoArgsCtrCheck),
+          Seq(NoArgsCtrCheck)))
       checks.startupResult().futureValue shouldEqual Right(())
       checks.aliveResult().futureValue shouldEqual Right(())
       checks.readyResult().futureValue shouldEqual Right(())
@@ -160,9 +159,9 @@ class HealthChecksSpec
       val checks = HealthChecks(
         eas,
         settings(
-          im.Seq(FalseCheck),
-          im.Seq(FalseCheck),
-          im.Seq(FalseCheck)))
+          Seq(FalseCheck),
+          Seq(FalseCheck),
+          Seq(FalseCheck)))
       checks.startupResult().futureValue.isRight shouldEqual false
       checks.readyResult().futureValue.isRight shouldEqual false
       checks.aliveResult().futureValue.isRight shouldEqual false
@@ -174,9 +173,9 @@ class HealthChecksSpec
       val checks = HealthChecks(
         eas,
         settings(
-          im.Seq(ThrowsCheck),
-          im.Seq(ThrowsCheck),
-          im.Seq(ThrowsCheck)))
+          Seq(ThrowsCheck),
+          Seq(ThrowsCheck),
+          Seq(ThrowsCheck)))
       checks.startupResult().failed.futureValue shouldEqual
       CheckFailedException("Check [org.apache.pekko.management.Throws] failed: null", failedCause)
       checks.readyResult().failed.futureValue shouldEqual
@@ -191,7 +190,7 @@ class HealthChecksSpec
       CheckFailedException("Check [org.apache.pekko.management.Throws] failed: null", failedCause)
     }
     "return failure if any of the checks fail" in {
-      val checks = im.Seq(
+      val checks = Seq(
         OkCheck,
         ThrowsCheck,
         FalseCheck)
@@ -210,7 +209,7 @@ class HealthChecksSpec
       CheckFailedException("Check [org.apache.pekko.management.Throws] failed: null", failedCause)
     }
     "return failure if check throws" in {
-      val checks = im.Seq(
+      val checks = Seq(
         NaughtyCheck)
       val hc = HealthChecks(eas, settings(checks, checks, checks))
       hc.startupResult().failed.futureValue.getMessage shouldEqual
@@ -224,7 +223,7 @@ class HealthChecksSpec
       hc.alive().failed.futureValue.getMessage shouldEqual "Check [org.apache.pekko.management.Naughty] failed: bad"
     }
     "return failure if checks timeout" in {
-      val checks = im.Seq(
+      val checks = Seq(
         SlowCheck,
         OkCheck)
       val hc = HealthChecks(eas, settings(checks, checks, checks))
@@ -243,14 +242,14 @@ class HealthChecksSpec
     }
     "provide useful error if user's ctr is invalid" in {
       intercept[InvalidHealthCheckException] {
-        val checks = im.Seq(InvalidCtrCheck)
+        val checks = Seq(InvalidCtrCheck)
         HealthChecks(eas, settings(checks, checks, checks))
       }.getMessage shouldEqual
       "Health checks: [NamedHealthCheck(InvalidCtr,org.apache.pekko.management.InvalidCtr)] must have a no args constructor or a single argument constructor that takes an ActorSystem"
     }
     "provide useful error if invalid type" in {
       intercept[InvalidHealthCheckException] {
-        val checks = im.Seq(WrongTypeCheck)
+        val checks = Seq(WrongTypeCheck)
         HealthChecks(eas, settings(checks, checks, checks))
       }.getMessage shouldEqual
       "Health checks: [NamedHealthCheck(WrongType,org.apache.pekko.management.WrongType)] must have type: () => Future[Boolean]"
@@ -258,14 +257,14 @@ class HealthChecksSpec
     "provide useful error if class not found" in {
       intercept[InvalidHealthCheckException] {
         val checks =
-          im.Seq(DoesNotExist, OkCheck)
+          Seq(DoesNotExist, OkCheck)
         HealthChecks(eas, settings(checks, checks, checks))
       }.getMessage shouldEqual "Health check: [org.apache.pekko.management.DoesNotExist] not found"
     }
     "provide useful error if class ctr throws" in {
       intercept[InvalidHealthCheckException] {
         val checks =
-          im.Seq(OkCheck, CtrExceptionCheck)
+          Seq(OkCheck, CtrExceptionCheck)
         HealthChecks(eas, settings(checks, checks, checks))
       }.getCause shouldEqual ctxException
     }

--- a/rolling-update-kubernetes/src/main/scala/org/apache/pekko/rollingupdate/kubernetes/KubernetesApi.scala
+++ b/rolling-update-kubernetes/src/main/scala/org/apache/pekko/rollingupdate/kubernetes/KubernetesApi.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.rollingupdate.kubernetes
 import java.text.Normalizer
 import java.util.Locale
 
-import scala.collection.immutable
 import scala.concurrent.Future
 
 import org.apache.pekko
@@ -29,7 +28,7 @@ import pekko.cluster.UniqueAddress
  * INTERNAL API
  */
 @InternalApi
-private[pekko] final case class PodCostResource(version: String, pods: immutable.Seq[PodCost])
+private[pekko] final case class PodCostResource(version: String, pods: Seq[PodCost])
 
 /**
  * INTERNAL API
@@ -138,6 +137,6 @@ private[pekko] trait KubernetesApi {
   def updatePodCostResource(
       crName: String,
       version: String,
-      pods: immutable.Seq[PodCost]): Future[Either[PodCostResource, PodCostResource]]
+      pods: Seq[PodCost]): Future[Either[PodCostResource, PodCostResource]]
 
 }

--- a/rolling-update-kubernetes/src/main/scala/org/apache/pekko/rollingupdate/kubernetes/KubernetesApiImpl.scala
+++ b/rolling-update-kubernetes/src/main/scala/org/apache/pekko/rollingupdate/kubernetes/KubernetesApiImpl.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.rollingupdate.kubernetes
 
 import java.util.Locale
 import java.nio.charset.StandardCharsets
-import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
@@ -68,7 +67,7 @@ import java.nio.file.Paths
   private val http = Http()(system)
 
   private val scheme = if (settings.secure) "https" else "http"
-  private lazy val headers = if (settings.secure) immutable.Seq(Authorization(OAuth2BearerToken(apiToken))) else Nil
+  private lazy val headers = if (settings.secure) Seq(Authorization(OAuth2BearerToken(apiToken))) else Nil
 
   log.debug("kubernetes access namespace: {}. Secure: {}", namespace, settings.secure)
 
@@ -152,7 +151,7 @@ PUTs must contain resourceVersions. Response:
   override def updatePodCostResource(
       crName: String,
       version: String,
-      pods: immutable.Seq[PodCost]): Future[Either[PodCostResource, PodCostResource]] = {
+      pods: Seq[PodCost]): Future[Either[PodCostResource, PodCostResource]] = {
     val cr = PodCostCustomResource(Metadata(crName, Some(version)), Spec(pods))
     for {
       entity <- Marshal(cr).to[RequestEntity]

--- a/rolling-update-kubernetes/src/main/scala/org/apache/pekko/rollingupdate/kubernetes/KubernetesJsonSupport.scala
+++ b/rolling-update-kubernetes/src/main/scala/org/apache/pekko/rollingupdate/kubernetes/KubernetesJsonSupport.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.rollingupdate.kubernetes
 
-import scala.collection.immutable
-
 import org.apache.pekko.annotation.InternalApi
 import org.apache.pekko.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import spray.json.DefaultJsonProtocol
@@ -49,7 +47,7 @@ case class PodOwnerRef(name: String, kind: String)
  * INTERNAL API
  */
 @InternalApi
-case class PodMetadata(ownerReferences: immutable.Seq[PodOwnerRef])
+case class PodMetadata(ownerReferences: Seq[PodOwnerRef])
 
 /**
  * INTERNAL API
@@ -77,7 +75,7 @@ case class Metadata(name: String, resourceVersion: Option[String])
  * INTERNAL API
  */
 @InternalApi
-case class Spec(pods: immutable.Seq[PodCost])
+case class Spec(pods: Seq[PodCost])
 
 /**
  * INTERNAL API

--- a/rolling-update-kubernetes/src/test/scala/org/apache/pekko/rollingupdate/kubernetes/PodDeletionCostAnnotatorCrSpec.scala
+++ b/rolling-update-kubernetes/src/test/scala/org/apache/pekko/rollingupdate/kubernetes/PodDeletionCostAnnotatorCrSpec.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.rollingupdate.kubernetes
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
@@ -79,7 +78,7 @@ object PodDeletionCostAnnotatorCrSpec {
     override def updatePodCostResource(
         crName: String,
         v: String,
-        pods: immutable.Seq[PodCost]): Future[Either[PodCostResource, PodCostResource]] = this.synchronized {
+        pods: Seq[PodCost]): Future[Either[PodCostResource, PodCostResource]] = this.synchronized {
 
       podCosts = pods.toVector
       version = v.toInt + 1


### PR DESCRIPTION
### Motivation
The codebase still carried the Scala 2.12-era `immutable.Seq` qualifier (and its `scala.collection.immutable` / `scala.collection.immutable.Seq` imports). On Scala 2.13 and 3, `scala.Seq` is already an alias for `scala.collection.immutable.Seq`, so the qualifier is redundant. This is the pekko-management equivalent of apache/pekko#3539.

Unlike the core repo, there were no other 2.12 idioms to clean up here: no `WrappedArray`, `filterKeys`/`mapValues`, `.toIterator`, `Stream`, or `Either` projections, and no paradox anchors referencing `immutable.Seq`.

### Modification
- Replace `immutable.Seq` with `Seq` across 24 files and drop the now-unused `scala.collection.immutable`, `scala.collection.immutable.Seq` and `scala.collection.{ immutable => im }` imports.
- Files that still use other `immutable.*` types (`Set`, `Iterable`, `SortedSet`) keep the `scala.collection.immutable` import (`ClusterHttpManagementProtocol`, `BootstrapCoordinator`, `PodDeletionCostAnnotator`).
- `ClusterHttpManagementRoutesSpec`: swap the `scala.collection.immutable._` wildcard for an explicit `SortedSet` import.
- `ConsulServiceDiscovery`: drop the redundant `scala.collection.immutable.Seq(targets: _*)` copy, since `targets` is already an immutable `Seq`.

### Result
No remaining Scala 2.12 collection idioms in main or test sources. Source- and binary-compatible: `Seq` has the same erasure, so MiMa passes without new filters.

### Tests
- native `scalafmt --mode diff-ref=upstream/main`
- `sbt +Test/compile` passes on Scala 2.13, 3.3 and 3-next
- `sbt <module>/mimaReportBinaryIssues` passes for all touched modules (management, management-cluster-http, management-cluster-bootstrap, discovery-kubernetes-api, discovery-marathon-api, discovery-aws-api, discovery-aws-api-async, discovery-consul, lease-kubernetes, rolling-update-kubernetes)
- `sbt <module>/test` passes for all touched modules; `ConsulDiscoverySpec` not run locally as it requires Docker/testcontainers (relying on CI)

### References
None - equivalent of apache/pekko#3539
